### PR TITLE
[오민지] 5주차 과제 제출

### DIFF
--- a/src/main/java/efub/assignment/community/CommunityApplication.java
+++ b/src/main/java/efub/assignment/community/CommunityApplication.java
@@ -2,8 +2,10 @@ package efub.assignment.community;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CommunityApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/efub/assignment/community/board/controller/BoardController.java
+++ b/src/main/java/efub/assignment/community/board/controller/BoardController.java
@@ -1,0 +1,47 @@
+package efub.assignment.community.board.controller;
+
+import efub.assignment.community.board.dto.BoardCreateRequestDto;
+import efub.assignment.community.board.dto.BoardResponseDto;
+import efub.assignment.community.post.dto.PostListResponseDto;
+import efub.assignment.community.board.dto.UpdateOwnerRequestDto;
+import efub.assignment.community.board.service.BoardService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("boards")
+public class BoardController {
+    private final BoardService boardService;
+
+    // 게시판 생성
+    @PostMapping
+    public ResponseEntity<BoardResponseDto> createBoard(@Valid @RequestBody BoardCreateRequestDto boardCreateRequestDto) {
+        BoardResponseDto boardResponseDto = boardService.createBoard(boardCreateRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(boardResponseDto);
+    }
+
+    // 게시판 조회
+    @GetMapping("/{boardId}")
+    public ResponseEntity<BoardResponseDto> getBoard(@PathVariable Long boardId) {
+        BoardResponseDto boardResponseDto = boardService.getBoard(boardId);
+        return ResponseEntity.status(HttpStatus.OK).body(boardResponseDto);
+    }
+
+    // 게시판 소유자 수정
+    @PatchMapping("/{boardId}/owner")
+    public ResponseEntity<BoardResponseDto> changeOwner(@PathVariable Long boardId, @Valid @RequestBody UpdateOwnerRequestDto updateOwnerRequestDto) {
+        BoardResponseDto boardResponseDto = boardService.updateOwner(boardId, updateOwnerRequestDto);
+        return ResponseEntity.status(HttpStatus.OK).body(boardResponseDto);
+    }
+
+    // 게시판 삭제
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<String> deleteBoard(@PathVariable Long boardId) {
+        boardService.deleteBoard(boardId);
+        return ResponseEntity.ok("성공적으로 게시판 삭제가 완료되었습니다.");
+    }
+}

--- a/src/main/java/efub/assignment/community/board/domain/Board.java
+++ b/src/main/java/efub/assignment/community/board/domain/Board.java
@@ -1,0 +1,50 @@
+package efub.assignment.community.board.domain;
+
+import efub.assignment.community.global.domain.BaseEntity;
+import efub.assignment.community.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "boards")
+public class Board extends BaseEntity {
+
+    // Id
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long boardId;
+
+    // 게시판 소유자
+    @ManyToOne
+    @JoinColumn (name = "memberId", nullable = false)
+    private Member owner;
+
+    // 게시판 이름
+    @Column
+    private String name;
+
+    // 게시판 설명
+    @Column (nullable = true)
+    private String description;
+
+    // 게시판 공지
+    @Column (nullable = true)
+    private String notice;
+
+    @Builder
+    public Board(Member owner, String description, String notice, String name) {
+        this.owner = owner;
+        this.description = description;
+        this.notice = notice;
+        this.name = name;
+    }
+
+    public void updateOwner(Member newOwner) {
+        this.owner = newOwner;
+    }
+}

--- a/src/main/java/efub/assignment/community/board/dto/BoardCreateRequestDto.java
+++ b/src/main/java/efub/assignment/community/board/dto/BoardCreateRequestDto.java
@@ -1,0 +1,23 @@
+package efub.assignment.community.board.dto;
+
+import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.member.domain.Member;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.lang.Nullable;
+
+public record BoardCreateRequestDto(@NotBlank String name,
+                                    @Nullable String description,
+                                    @Nullable String notice,
+                                    @NotNull Long ownerId) { // record -> 불변성 보장, DTO에 적합
+
+    public Board toEntity(Member member) {
+        return Board.builder()
+                .name(name)
+                .description(description)
+                .notice(notice)
+                .owner(member)
+                .build();
+
+    }
+}

--- a/src/main/java/efub/assignment/community/board/dto/BoardResponseDto.java
+++ b/src/main/java/efub/assignment/community/board/dto/BoardResponseDto.java
@@ -1,0 +1,32 @@
+package efub.assignment.community.board.dto;
+
+import efub.assignment.community.board.domain.Board;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class BoardResponseDto {
+    private Long boardId;
+    private String name;
+    private String description;
+    private String notice;
+    private Long ownerId;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static BoardResponseDto from(Board board) {
+        return BoardResponseDto.builder()
+                .boardId(board.getBoardId())
+                .name(board.getName())
+                .description(board.getDescription())
+                .notice(board.getNotice())
+                .ownerId(board.getOwner().getMemberId())
+                .createdAt(board.getCreatedAt())
+                .updatedAt(board.getUpdatedAt())
+                .build();
+
+    }
+}

--- a/src/main/java/efub/assignment/community/board/dto/UpdateOwnerRequestDto.java
+++ b/src/main/java/efub/assignment/community/board/dto/UpdateOwnerRequestDto.java
@@ -1,0 +1,11 @@
+package efub.assignment.community.board.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateOwnerRequestDto {
+
+    private Long ownerId;
+}

--- a/src/main/java/efub/assignment/community/board/repository/BoardRepository.java
+++ b/src/main/java/efub/assignment/community/board/repository/BoardRepository.java
@@ -1,0 +1,11 @@
+package efub.assignment.community.board.repository;
+
+import efub.assignment.community.board.domain.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+    Optional<Board> findByBoardId(Long boardId);
+    void deleteByBoardId(Long boardId);
+}

--- a/src/main/java/efub/assignment/community/board/service/BoardService.java
+++ b/src/main/java/efub/assignment/community/board/service/BoardService.java
@@ -1,0 +1,58 @@
+package efub.assignment.community.board.service;
+
+import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.board.dto.BoardCreateRequestDto;
+import efub.assignment.community.board.dto.BoardResponseDto;
+import efub.assignment.community.board.dto.UpdateOwnerRequestDto;
+import efub.assignment.community.board.repository.BoardRepository;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+    private final BoardRepository boardRepository;
+    private final MemberRepository memberRepository;
+
+    // 게시판 생성
+    @Transactional
+    public BoardResponseDto createBoard(BoardCreateRequestDto boardCreateRequestDto) {
+        Long ownerId = boardCreateRequestDto.ownerId();
+        Member owner = memberRepository.findByMemberId(ownerId)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+        Board Board = boardCreateRequestDto.toEntity(owner);
+        Board savedBoard = boardRepository.save(Board);
+        return BoardResponseDto.from(savedBoard);
+    }
+
+    // 게시판 조회
+    @Transactional
+    public BoardResponseDto getBoard(Long boardId) {
+        Board board = boardRepository.findByBoardId(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("Board not found"));
+        return BoardResponseDto.from(board);
+    }
+
+    // 게시판 소유자 수정
+    @Transactional
+    public BoardResponseDto updateOwner(Long boardId, @Valid @RequestBody UpdateOwnerRequestDto updateOwnerRequestDto) {
+        Board board = boardRepository.findByBoardId(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("Board not found"));
+        Member newOwner = memberRepository.findByMemberId(updateOwnerRequestDto.getOwnerId())
+                        .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+        board.updateOwner(newOwner);
+        return BoardResponseDto.from(boardRepository.save(board));
+    }
+
+    // 게시판 삭제
+    @Transactional
+    public void deleteBoard(Long boardId) {
+        boardRepository.deleteByBoardId(boardId);
+    }
+}

--- a/src/main/java/efub/assignment/community/global/domain/BaseEntity.java
+++ b/src/main/java/efub/assignment/community/global/domain/BaseEntity.java
@@ -1,0 +1,24 @@
+package efub.assignment.community.global.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+    // 생성 일시
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    // 수정 일시
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/efub/assignment/community/member/controller/MemberController.java
+++ b/src/main/java/efub/assignment/community/member/controller/MemberController.java
@@ -42,6 +42,6 @@ public class MemberController {
     @PatchMapping("/{memberId}")
     public ResponseEntity<String> deleteMember(@PathVariable("memberId") Long memberId) {
         memberService.deleteMember(memberId);
-        return ResponseEntity.ok("삭제가 완료되었습니다.");
+        return ResponseEntity.ok("성공적으로 탈퇴가 완료되었습니다.");
     }
 }

--- a/src/main/java/efub/assignment/community/member/domain/Member.java
+++ b/src/main/java/efub/assignment/community/member/domain/Member.java
@@ -1,5 +1,6 @@
 package efub.assignment.community.member.domain;
 
+import efub.assignment.community.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @Table(name = "members")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseEntity {
 
     // ID
     @Id
@@ -43,26 +44,6 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private MemberStatus status = MemberStatus.ACTIVE;
 
-    // 생성일
-    @Column (nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    // 수정일
-    @Column
-    private LocalDateTime updatedAt;
-
-    // 생성 시 시간 저장
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-    }
-
-    // 수정 시 시간 저장
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
-
     @Builder
     public Member(String studentId, String university, String nickname, String email, String password) {
         this.studentId = studentId;
@@ -70,10 +51,10 @@ public class Member {
         this.nickname = nickname;
         this.email = email;
         this.password = password;
-        this.status = MemberStatus.ACTIVE; // 빌더 패턴은 수정되는 값들로부터 보호하기 위해 사용한다고 세미나에서 말씀해주셨는데, 처음 설정되는 값을 모두 포함시키는 것보다 수정되는 nickname과 status를 포함하지 않는 게 더 나을까?
+        this.status = MemberStatus.ACTIVE;
     }
 
-    public void updateMember(String nickname) {
+    public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
 

--- a/src/main/java/efub/assignment/community/member/dto/ErrorResponseDto.java
+++ b/src/main/java/efub/assignment/community/member/dto/ErrorResponseDto.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
-public class ErrorResponseDto { // 세미나 실습에선 전역 에러 핸들러 만들었었는데 이 과제에도 추가하는 게 좋을까?
+public class ErrorResponseDto {
 
     private LocalDateTime timestamp;
     private int status;

--- a/src/main/java/efub/assignment/community/member/repository/MemberRepository.java
+++ b/src/main/java/efub/assignment/community/member/repository/MemberRepository.java
@@ -11,5 +11,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     // 학번 중복검사를 위한 쿼리
     boolean existsByEmail(String email);
     // 멤버 ID로 조회
-    Optional<Member> findBymemberId(Long memberId);
+    Optional<Member> findByMemberId(Long memberId);
 }

--- a/src/main/java/efub/assignment/community/member/service/MemberService.java
+++ b/src/main/java/efub/assignment/community/member/service/MemberService.java
@@ -42,7 +42,7 @@ public class MemberService {
     @Transactional
     // 닉네임 수정
     public MemberResponseDto updateMember(Long memberId, MemberRequestDto memberRequestDto) {
-        Member member = memberRepository.findBymemberId(memberId)
+        Member member = memberRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("Member not found"));
 
         member.updateNickname(memberRequestDto.getNickname());
@@ -53,7 +53,7 @@ public class MemberService {
     @Transactional
     // 회원 탈퇴 (상태 변경)
     public void deleteMember(Long memberId) {
-        Member member = memberRepository.findBymemberId(memberId)
+        Member member = memberRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("Member not found"));
 
         member.changeStatus(MemberStatus.DEACTIVATED);

--- a/src/main/java/efub/assignment/community/member/service/MemberService.java
+++ b/src/main/java/efub/assignment/community/member/service/MemberService.java
@@ -5,17 +5,17 @@ import efub.assignment.community.member.domain.MemberStatus;
 import efub.assignment.community.member.dto.MemberRequestDto;
 import efub.assignment.community.member.dto.MemberResponseDto;
 import efub.assignment.community.member.repository.MemberRepository;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    @Transactional
     // 회원 생성
     public MemberResponseDto createMember(MemberRequestDto memberRequestDto) {
         // 이메일 중복 검사
@@ -32,22 +32,25 @@ public class MemberService {
     }
 
     // 회원 조회
+    @Transactional(readOnly = true)
     public MemberResponseDto getMember(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("Member not found"));
         return MemberResponseDto.from(member);
     }
 
+    @Transactional
     // 닉네임 수정
     public MemberResponseDto updateMember(Long memberId, MemberRequestDto memberRequestDto) {
         Member member = memberRepository.findBymemberId(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("Member not found"));
 
-        member.updateMember(memberRequestDto.getNickname());
+        member.updateNickname(memberRequestDto.getNickname());
         Member savedMember = memberRepository.save(member);
         return MemberResponseDto.from(savedMember);
     }
 
+    @Transactional
     // 회원 탈퇴 (상태 변경)
     public void deleteMember(Long memberId) {
         Member member = memberRepository.findBymemberId(memberId)

--- a/src/main/java/efub/assignment/community/post/controller/PostController.java
+++ b/src/main/java/efub/assignment/community/post/controller/PostController.java
@@ -1,0 +1,57 @@
+package efub.assignment.community.post.controller;
+
+import efub.assignment.community.post.dto.PostCreateRequestDto;
+import efub.assignment.community.post.dto.PostListResponseDto;
+import efub.assignment.community.post.dto.PostResponseDto;
+import efub.assignment.community.post.dto.UpdateContentDto;
+import efub.assignment.community.post.repository.PostRepository;
+import efub.assignment.community.post.service.PostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("posts")
+public class PostController {
+
+    private final PostService postService;
+    private final PostRepository postRepository;
+
+    // 게시글 생성
+    @PostMapping
+    public ResponseEntity<PostResponseDto> createPost(@Valid @RequestBody PostCreateRequestDto postCreateRequestDto) {
+        PostResponseDto postResponseDto = postService.createPost(postCreateRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(postResponseDto);
+    }
+
+    // 게시글 수정
+    @PatchMapping("/{postId}")
+    public ResponseEntity<PostResponseDto> updateContent(@PathVariable Long postId, @Valid @RequestBody UpdateContentDto updateContentDto) {
+        PostResponseDto postResponseDto = postService.updateContent(postId, updateContentDto);
+        return ResponseEntity.status(HttpStatus.OK).body(postResponseDto);
+    }
+
+    // 게시글 내용 상세 조회
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostResponseDto> getPost(@PathVariable Long postId) {
+        PostResponseDto postResponseDto = postService.getPost(postId);
+        return ResponseEntity.status(HttpStatus.OK).body(postResponseDto);
+    }
+
+    // 게시글 목록 조회
+    @GetMapping("/{boardId}/list")
+    public ResponseEntity<PostListResponseDto> getPosts(@PathVariable Long boardId) {
+        PostListResponseDto postListResponseDto = postService.getPostList(boardId);
+        return ResponseEntity.status(HttpStatus.OK).body(postListResponseDto);
+    }
+
+    // 게시글 삭제
+    @DeleteMapping("{postId}")
+    public ResponseEntity<String> deletePost(@PathVariable Long postId) {
+        postService.deletePost(postId);
+        return ResponseEntity.ok("성공적으로 게시글 삭제가 완료되었습니다.");
+    }
+}

--- a/src/main/java/efub/assignment/community/post/domain/Post.java
+++ b/src/main/java/efub/assignment/community/post/domain/Post.java
@@ -1,0 +1,53 @@
+package efub.assignment.community.post.domain;
+
+import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.global.domain.BaseEntity;
+import efub.assignment.community.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor (access = AccessLevel.PROTECTED)
+@Table(name = "posts")
+public class Post extends BaseEntity {
+
+    // Id
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long postId;
+
+    // 게시판
+    @ManyToOne
+    @JoinColumn(name = "boardId", nullable = false)
+    private Board board;
+
+    // 작성자
+    @ManyToOne
+    @JoinColumn(name = "memberId", nullable = false)
+    private Member author;
+
+    // 익명
+    @Column(nullable = false)
+    private boolean anonymous;
+
+    // 내용
+    @Column(nullable = false)
+    private String content;
+
+    @Builder
+    private Post (Long postId, Board board, Member author, boolean anonymous, String content) {
+        this.postId = postId;
+        this.board = board;
+        this.author = author;
+        this.anonymous = anonymous;
+        this.content = content;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/efub/assignment/community/post/dto/PostCreateRequestDto.java
+++ b/src/main/java/efub/assignment/community/post/dto/PostCreateRequestDto.java
@@ -1,0 +1,21 @@
+package efub.assignment.community.post.dto;
+
+import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.post.domain.Post;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record PostCreateRequestDto(@NotNull Long boardId,
+                                  boolean anonymous,
+                                  @NotNull Long authorId,
+                                  @NotBlank String content) {
+    public Post toEntity(Board board, Member author) {
+        return Post.builder()
+                .board(board)
+                .anonymous(anonymous)
+                .author(author)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/efub/assignment/community/post/dto/PostListResponseDto.java
+++ b/src/main/java/efub/assignment/community/post/dto/PostListResponseDto.java
@@ -1,0 +1,18 @@
+package efub.assignment.community.post.dto;
+
+import efub.assignment.community.post.domain.Post;
+
+import java.util.List;
+
+public record PostListResponseDto(Long boardId,
+                                  int count,
+                                  List<PostResponseDto> posts) {
+
+    public static PostListResponseDto from(Long boardId, List<Post> posts) {
+        List<PostResponseDto> postDtos = posts.stream()
+                .map(PostResponseDto::from)
+                .toList();
+
+        return new PostListResponseDto(boardId, postDtos.size(), postDtos);
+    }
+}

--- a/src/main/java/efub/assignment/community/post/dto/PostResponseDto.java
+++ b/src/main/java/efub/assignment/community/post/dto/PostResponseDto.java
@@ -1,0 +1,31 @@
+package efub.assignment.community.post.dto;
+
+import efub.assignment.community.post.domain.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class PostResponseDto {
+    private Long postId;
+    private Long boardId;
+    private Long authorId;
+    private boolean anonymous;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static PostResponseDto from(Post post) {
+        return PostResponseDto.builder()
+                .postId(post.getPostId())
+                .boardId(post.getBoard().getBoardId())
+                .authorId(post.getAuthor().getMemberId())
+                .anonymous(post.isAnonymous())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/efub/assignment/community/post/dto/UpdateContentDto.java
+++ b/src/main/java/efub/assignment/community/post/dto/UpdateContentDto.java
@@ -1,0 +1,10 @@
+package efub.assignment.community.post.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateContentDto {
+    private String content;
+}

--- a/src/main/java/efub/assignment/community/post/repository/PostRepository.java
+++ b/src/main/java/efub/assignment/community/post/repository/PostRepository.java
@@ -1,0 +1,16 @@
+package efub.assignment.community.post.repository;
+
+import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.post.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    Optional<Post> findByPostId(Long postId);
+
+    void deleteByPostId(Long postId);
+
+    List<Post> findAllByBoard(Board board);
+}

--- a/src/main/java/efub/assignment/community/post/service/PostService.java
+++ b/src/main/java/efub/assignment/community/post/service/PostService.java
@@ -1,0 +1,70 @@
+package efub.assignment.community.post.service;
+
+import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.board.repository.BoardRepository;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.repository.MemberRepository;
+import efub.assignment.community.post.domain.Post;
+import efub.assignment.community.post.dto.PostCreateRequestDto;
+import efub.assignment.community.post.dto.PostListResponseDto;
+import efub.assignment.community.post.dto.PostResponseDto;
+import efub.assignment.community.post.dto.UpdateContentDto;
+import efub.assignment.community.post.repository.PostRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final BoardRepository boardRepository;
+    private final MemberRepository memberRepository;
+
+    // 게시글 생성
+    public PostResponseDto createPost(@Valid PostCreateRequestDto postCreateRequestDto) {
+        Board board = boardRepository.findByBoardId(postCreateRequestDto.boardId())
+                .orElseThrow(() -> new RuntimeException("Board not found"));
+        Member author = memberRepository.findByMemberId(postCreateRequestDto.authorId())
+                .orElseThrow(() -> new RuntimeException("Member not found"));
+        Post post = postCreateRequestDto.toEntity(board, author);
+        Post savedPost = postRepository.save(post);
+        return PostResponseDto.from(savedPost);
+    }
+
+    // 게시글 수정
+    public PostResponseDto updateContent(@PathVariable Long postId, @Valid UpdateContentDto updateContentDto) {
+        Post post = postRepository.findByPostId(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+        String newContent = updateContentDto.getContent();
+        post.updateContent(newContent);
+        Post savedPost = postRepository.save(post);
+        return PostResponseDto.from(savedPost);
+    }
+
+    // 게시글 상세 내용 조회
+    public PostResponseDto getPost(@PathVariable Long postId) {
+        Post post = postRepository.findByPostId(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+        return PostResponseDto.from(post);
+    }
+
+    // 게시글 목록 조회
+    public PostListResponseDto getPostList(@PathVariable Long boardId) {
+        Board board = boardRepository.findByBoardId(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("Board not found"));
+        List<Post> postList = postRepository.findAllByBoard(board);
+        return PostListResponseDto.from(boardId, postList);
+    }
+
+    // 게시글 삭제
+    public void deletePost(@PathVariable Long postId) {
+        postRepository.deleteByPostId(postId);
+    }
+}


### PR DESCRIPTION
## 📌 구현 기능  
- [x] 게시판 CRUD API: 게시판 생성, 게시판 정보 조회, 게시판 소유자 변경, 게시판 삭제
- [x] 게시글 CRUP API: 게시글 생성, 게시글 내용 상세 조회, 게시글 목록 조회, 게시글 내용 수정, 게시글 삭제

## 🗂️ 과제 정리  
1. 게시판 CRUDAPI
- 게시판 생성
![image](https://github.com/user-attachments/assets/f67b3bee-a2e7-4331-b3eb-98bc27042902)
- 게시판 정보 조회
![image](https://github.com/user-attachments/assets/dc593efc-cb9e-4fe7-84af-25340198038f)
- 게시판 소유자 변경
![image](https://github.com/user-attachments/assets/43610629-5c52-4d08-8377-6525535f5730)
- 게시판 삭제
![image](https://github.com/user-attachments/assets/ccc7b223-64fa-481b-bf2e-566dd1c17f5a)

2. 게시글 CRUD API
- 게시글 생성
![image](https://github.com/user-attachments/assets/49ef54ef-17bc-4d60-b012-0a89d576b64b)
- 게시글 내용 수정
![image](https://github.com/user-attachments/assets/1cc51a43-c888-4da8-9153-56687251306d)
- 게시글 내용 상세 조회
![image](https://github.com/user-attachments/assets/6f42fc4d-3ecf-4476-a24e-1f4311570164)
- 게시글 목록 조회
![image](https://github.com/user-attachments/assets/30b9d827-7b10-40a5-85b3-d84c3489753d)
- 게시글 삭제
![image](https://github.com/user-attachments/assets/8be0ede9-2181-4326-ac0d-3b67fd88d647)

## ⚠️ 어려웠던 점  
- 게시글 목록 조회 시 사용할 DTO 만드는 부분이 조금 까다로웠습니다.
