### PR TITLE
[홍지형] 11주차 과제 제출

### DIFF
--- a/src/main/java/efub/assignment/community/board/domain/BoardSearchKeyword.java
+++ b/src/main/java/efub/assignment/community/board/domain/BoardSearchKeyword.java
@@ -21,6 +21,11 @@ public class BoardSearchKeyword {
 
     @Builder
     public BoardSearchKeyword(String keyword) {
-        this.keyword = keyword;
+        if(keyword == null){
+            throw new IllegalArgumentException("키워드가 null이면 안됩니다.");
+        }
+        if(keyword.isEmpty()){
+            throw new IllegalArgumentException("키워드가 빈문자열이면 안됩니다");
+        }
     }
 }

--- a/src/main/java/efub/assignment/community/board/domain/BoardSearchKeyword.java
+++ b/src/main/java/efub/assignment/community/board/domain/BoardSearchKeyword.java
@@ -1,0 +1,26 @@
+package efub.assignment.community.board.domain;
+
+import efub.assignment.community.global.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoardSearchKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(nullable = false)
+    private String keyword;
+
+    @Builder
+    public BoardSearchKeyword(String keyword) {
+        this.keyword = keyword;
+    }
+}

--- a/src/main/java/efub/assignment/community/board/domain/BoardSearchKeyword.java
+++ b/src/main/java/efub/assignment/community/board/domain/BoardSearchKeyword.java
@@ -17,7 +17,7 @@ public class BoardSearchKeyword extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;
+    private Long id;
 
     @Column(nullable = false)
     private String keyword;

--- a/src/main/java/efub/assignment/community/board/domain/BoardSearchKeyword.java
+++ b/src/main/java/efub/assignment/community/board/domain/BoardSearchKeyword.java
@@ -6,11 +6,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedBy;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class BoardSearchKeyword {
+public class BoardSearchKeyword extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,5 +30,6 @@ public class BoardSearchKeyword {
         if(keyword.isEmpty()){
             throw new IllegalArgumentException("키워드가 빈문자열이면 안됩니다");
         }
+        this.keyword = keyword;
     }
 }

--- a/src/main/java/efub/assignment/community/board/dto/response/BoardSimpleResponse.java
+++ b/src/main/java/efub/assignment/community/board/dto/response/BoardSimpleResponse.java
@@ -1,0 +1,12 @@
+package efub.assignment.community.board.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BoardSimpleResponse {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/efub/assignment/community/board/dto/response/BoardSimpleResponse.java
+++ b/src/main/java/efub/assignment/community/board/dto/response/BoardSimpleResponse.java
@@ -1,7 +1,6 @@
 package efub.assignment.community.board.dto.response;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/efub/assignment/community/board/repository/BoardRepository.java
+++ b/src/main/java/efub/assignment/community/board/repository/BoardRepository.java
@@ -3,9 +3,11 @@ package efub.assignment.community.board.repository;
 import efub.assignment.community.board.domain.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
     Optional<Board> findByBoardId(Long boardId);
     void deleteByBoardId(Long boardId);
+    List<Board> findByNameContaining(String name);
 }

--- a/src/main/java/efub/assignment/community/board/repository/BoardSearchKeywordRepository.java
+++ b/src/main/java/efub/assignment/community/board/repository/BoardSearchKeywordRepository.java
@@ -1,0 +1,7 @@
+package efub.assignment.community.board.repository;
+
+import efub.assignment.community.board.domain.BoardSearchKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardSearchKeywordRepository extends JpaRepository<BoardSearchKeyword,Long> {
+}

--- a/src/main/java/efub/assignment/community/board/service/BoardSearchKeywordService.java
+++ b/src/main/java/efub/assignment/community/board/service/BoardSearchKeywordService.java
@@ -1,0 +1,23 @@
+package efub.assignment.community.board.service;
+
+import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.board.dto.response.BoardSimpleResponse;
+import efub.assignment.community.board.repository.BoardRepository;
+import efub.assignment.community.board.repository.BoardSearchKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BoardSearchKeywordService {
+    private final BoardSearchKeywordRepository boardSearchKeywordRepository;
+    private final BoardRepository boardRepository;
+
+    public List<BoardSimpleResponse> searchByName(String keyword) {
+        return boardRepository.findByNameContaining(keyword).stream()
+                .map(board -> new BoardSimpleResponse(board.getBoardId(), board.getName())).toList();
+    }
+
+}

--- a/src/main/java/efub/assignment/community/board/service/BoardSearchKeywordService.java
+++ b/src/main/java/efub/assignment/community/board/service/BoardSearchKeywordService.java
@@ -1,6 +1,7 @@
 package efub.assignment.community.board.service;
 
 import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.board.domain.BoardSearchKeyword;
 import efub.assignment.community.board.dto.response.BoardSimpleResponse;
 import efub.assignment.community.board.repository.BoardRepository;
 import efub.assignment.community.board.repository.BoardSearchKeywordRepository;
@@ -16,6 +17,9 @@ public class BoardSearchKeywordService {
     private final BoardRepository boardRepository;
 
     public List<BoardSimpleResponse> searchByName(String keyword) {
+        boardSearchKeywordRepository.save(BoardSearchKeyword.builder()
+                        .keyword(keyword)
+                        .build());
         return boardRepository.findByNameContaining(keyword).stream()
                 .map(board -> new BoardSimpleResponse(board.getBoardId(), board.getName())).toList();
     }

--- a/src/test/java/efub/assignment/community/Board/Domain/BoardSearchKeywordTest.java
+++ b/src/test/java/efub/assignment/community/Board/Domain/BoardSearchKeywordTest.java
@@ -12,4 +12,9 @@ public class BoardSearchKeywordTest {
     void 검색어가_null이면_예외발생(){
         assertThrows(IllegalArgumentException.class, () -> BoardSearchKeyword.builder().keyword(null).build());
     }
+
+    @Test
+    void 검색어가_빈문자열이면_예외발생(){
+        assertThrows(IllegalArgumentException.class, () -> BoardSearchKeyword.builder().keyword("").build());
+    }
 }

--- a/src/test/java/efub/assignment/community/Board/Domain/BoardSearchKeywordTest.java
+++ b/src/test/java/efub/assignment/community/Board/Domain/BoardSearchKeywordTest.java
@@ -1,10 +1,13 @@
 package efub.assignment.community.Board.Domain;
 
+import efub.assignment.community.board.domain.Board;
 import efub.assignment.community.board.domain.BoardSearchKeyword;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BoardSearchKeywordTest {
 
@@ -16,5 +19,14 @@ public class BoardSearchKeywordTest {
     @Test
     void 검색어가_빈문자열이면_예외발생(){
         assertThrows(IllegalArgumentException.class, () -> BoardSearchKeyword.builder().keyword("").build());
+    }
+
+    @Test
+    void 일반적인_검색어면_엔티티생성(){
+        BoardSearchKeyword keyword = BoardSearchKeyword.builder()
+                .keyword("컴공벗")
+                .build();
+        assertNotNull(keyword);
+        assertEquals("컴공벗", keyword.getKeyword());
     }
 }

--- a/src/test/java/efub/assignment/community/Board/Domain/BoardSearchKeywordTest.java
+++ b/src/test/java/efub/assignment/community/Board/Domain/BoardSearchKeywordTest.java
@@ -13,12 +13,12 @@ public class BoardSearchKeywordTest {
 
     @Test
     void 검색어가_null이면_예외발생(){
-        assertThrows(IllegalArgumentException.class, () -> BoardSearchKeyword.builder().keyword(null).build());
+        검색어_잘못된값이면_예외발생(null);
     }
 
     @Test
     void 검색어가_빈문자열이면_예외발생(){
-        assertThrows(IllegalArgumentException.class, () -> BoardSearchKeyword.builder().keyword("").build());
+        검색어_잘못된값이면_예외발생("");
     }
 
     @Test
@@ -28,5 +28,9 @@ public class BoardSearchKeywordTest {
                 .build();
         assertNotNull(keyword);
         assertEquals("컴공벗", keyword.getKeyword());
+    }
+
+    void 검색어_잘못된값이면_예외발생(String keyword){
+        assertThrows(IllegalArgumentException.class, () -> BoardSearchKeyword.builder().keyword(keyword).build());
     }
 }

--- a/src/test/java/efub/assignment/community/Board/Domain/BoardSearchKeywordTest.java
+++ b/src/test/java/efub/assignment/community/Board/Domain/BoardSearchKeywordTest.java
@@ -1,0 +1,15 @@
+package efub.assignment.community.Board.Domain;
+
+import efub.assignment.community.board.domain.BoardSearchKeyword;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class BoardSearchKeywordTest {
+
+    @Test
+    void 검색어가_null이면_예외발생(){
+        assertThrows(IllegalArgumentException.class, () -> BoardSearchKeyword.builder().keyword(null).build());
+    }
+}

--- a/src/test/java/efub/assignment/community/Board/service/BoardSearchKeywordServiceTest.java
+++ b/src/test/java/efub/assignment/community/Board/service/BoardSearchKeywordServiceTest.java
@@ -6,52 +6,56 @@ import efub.assignment.community.board.repository.BoardRepository;
 import efub.assignment.community.board.repository.BoardSearchKeywordRepository;
 import efub.assignment.community.board.service.BoardSearchKeywordService;
 import efub.assignment.community.member.domain.Member;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 public class BoardSearchKeywordServiceTest {
-    @MockBean
+    @Mock
     private BoardRepository boardRepository;
 
-    @MockBean
+    @Mock
     private BoardSearchKeywordRepository keywordRepository;
 
-    @Autowired
+    @InjectMocks
     private BoardSearchKeywordService boardSearchKeywordService;
+
+    private Member member;
+
+    @BeforeEach
+    void setupMember() {
+        member = Member.builder()
+                .email("test@email.com")
+                .nickname("nickname")
+                .studentId("studentId")
+                .university("University")
+                .build();
+    }
 
     @Test
     void 게시판_이름_정확히_일치하면_검색된다(){
         String keyword = "컴공벗들모여라";
-        Member member = 기본_멤버_생성();
         Board board = 기본_게시판_생성(member, keyword);
         searchByNameAndAssert(keyword, List.of(board), keyword);
     }
 
     @Test
     void 검색어_일부_일치_시에도_반환한다() {
-        List<Board> boards = List.of("컴공벗들모여라", "컴공스터디").stream()
-                .map(name -> 기본_게시판_생성(기본_멤버_생성(), name))
+        List<Board> boards = Stream.of("컴공벗들모여라", "컴공스터디")
+                .map(name -> 기본_게시판_생성(member, name))
                 .toList();
 
         searchByNameAndAssert("컴공", boards, "컴공벗들모여라", "컴공스터디");
-    }
-
-    private Member 기본_멤버_생성(){
-        return Member.builder()
-                .email("test@email.com")
-                .nickname("nickname")
-                .studentId("studentId")
-                .university("University")
-                .build();
     }
 
     private Board 기본_게시판_생성(Member owner, String name){

--- a/src/test/java/efub/assignment/community/Board/service/BoardSearchKeywordServiceTest.java
+++ b/src/test/java/efub/assignment/community/Board/service/BoardSearchKeywordServiceTest.java
@@ -31,53 +31,46 @@ public class BoardSearchKeywordServiceTest {
     @Test
     void 게시판_이름_정확히_일치하면_검색된다(){
         String keyword = "컴공벗들모여라";
-        Member member = Member.builder()
-                .email("test@email.com")
-                .nickname("nickname")
-                .studentId("studentId")
-                .university("University")
-                .build();
-        Board board = Board.builder()
-                .owner(member)
-                .name(keyword)
-                .notice("모이셈")
-                .description("description")
-                .build();
-        given(boardRepository.findByNameContaining(keyword))
-                .willReturn(List.of(board));
-        List<BoardSimpleResponse> result = boardSearchKeywordService.searchByName(keyword);
-
-        assertEquals(1, result.size());
-        assertEquals(keyword, result.get(0).getName());
+        Member member = 기본_멤버_생성();
+        Board board = 기본_게시판_생성(member, keyword);
+        searchByNameAndAssert(keyword, List.of(board), keyword);
     }
 
     @Test
-    void 검색어_일부_일치_시에도_반환한다(){
-        Member member = Member.builder()
+    void 검색어_일부_일치_시에도_반환한다() {
+        List<Board> boards = List.of("컴공벗들모여라", "컴공스터디").stream()
+                .map(name -> 기본_게시판_생성(기본_멤버_생성(), name))
+                .toList();
+
+        searchByNameAndAssert("컴공", boards, "컴공벗들모여라", "컴공스터디");
+    }
+
+    private Member 기본_멤버_생성(){
+        return Member.builder()
                 .email("test@email.com")
                 .nickname("nickname")
                 .studentId("studentId")
                 .university("University")
                 .build();
+    }
 
-        Board board1 = Board.builder()
-                .owner(member)
-                .name("컴공벗들모여라")
+    private Board 기본_게시판_생성(Member owner, String name){
+        return Board.builder()
+                .owner(owner)
+                .name(name)
                 .notice("공지")
                 .description("설명")
                 .build();
+    }
 
-        Board board2 = Board.builder()
-                .owner(member)
-                .name("컴공스터디")
-                .notice("공지")
-                .description("설명")
-                .build();
-        given(boardRepository.findByNameContaining("컴공"))
-                .willReturn(List.of(board1, board2));
-        List<BoardSimpleResponse> result = boardSearchKeywordService.searchByName("컴공");
-        assertEquals(2, result.size());
-        assertTrue(result.stream().anyMatch(b -> b.getName().equals("컴공벗들모여라")));
-        assertTrue(result.stream().anyMatch(b -> b.getName().equals("컴공스터디")));
+    private void searchByNameAndAssert(String keyword, List<Board> stubBoards, String... expectedNames) {
+        given(boardRepository.findByNameContaining(keyword)).willReturn(stubBoards);
+
+        List<BoardSimpleResponse> result = boardSearchKeywordService.searchByName(keyword);
+
+        assertEquals(expectedNames.length, result.size());
+        for (String name : expectedNames) {
+            assertTrue(result.stream().anyMatch(b -> b.getName().equals(name)));
+        }
     }
 }

--- a/src/test/java/efub/assignment/community/Board/service/BoardSearchKeywordServiceTest.java
+++ b/src/test/java/efub/assignment/community/Board/service/BoardSearchKeywordServiceTest.java
@@ -12,11 +12,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
 import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,31 +34,46 @@ public class BoardSearchKeywordServiceTest {
     private BoardSearchKeywordService boardSearchKeywordService;
 
     private Member member;
+    private List<Board> allBoards;
 
     @BeforeEach
-    void setupMember() {
+    void setup() {
         member = Member.builder()
                 .email("test@email.com")
                 .nickname("nickname")
                 .studentId("studentId")
                 .university("University")
                 .build();
+        // 모든 테스트에서 사용할 게시판 리스트
+        allBoards = Stream.of("컴공벗들모여라", "컴공스터디", "운동동아리")
+                .map(name -> 기본_게시판_생성(member, name))
+                .toList();
+
+        // Stub: keyword 포함 게시판만 반환
+        given(boardRepository.findByNameContaining(anyString()))
+                .willAnswer((Answer<List<Board>>) invocation -> {
+                    String keyword = invocation.getArgument(0);
+                    return allBoards.stream()
+                            .filter(b -> b.getName().contains(keyword))
+                            .toList();
+                });
     }
 
     @Test
     void 게시판_이름_정확히_일치하면_검색된다(){
         String keyword = "컴공벗들모여라";
-        Board board = 기본_게시판_생성(member, keyword);
-        searchByNameAndAssert(keyword, List.of(board), keyword);
+        searchByNameAndAssert(keyword, keyword);
     }
 
     @Test
     void 검색어_일부_일치_시에도_반환한다() {
-        List<Board> boards = Stream.of("컴공벗들모여라", "컴공스터디")
-                .map(name -> 기본_게시판_생성(member, name))
-                .toList();
+        searchByNameAndAssert("컴공", "컴공벗들모여라", "컴공스터디");
+    }
 
-        searchByNameAndAssert("컴공", boards, "컴공벗들모여라", "컴공스터디");
+    @Test
+    void 검색어_일치하는_게시판_없으면_빈리스트(){
+        String keyword = "없는키워드";
+        searchByNameAndAssert(keyword);
     }
 
     private Board 기본_게시판_생성(Member owner, String name){
@@ -67,9 +85,7 @@ public class BoardSearchKeywordServiceTest {
                 .build();
     }
 
-    private void searchByNameAndAssert(String keyword, List<Board> stubBoards, String... expectedNames) {
-        given(boardRepository.findByNameContaining(keyword)).willReturn(stubBoards);
-
+    private void searchByNameAndAssert(String keyword, String... expectedNames) {
         List<BoardSimpleResponse> result = boardSearchKeywordService.searchByName(keyword);
 
         assertEquals(expectedNames.length, result.size());

--- a/src/test/java/efub/assignment/community/Board/service/BoardSearchKeywordServiceTest.java
+++ b/src/test/java/efub/assignment/community/Board/service/BoardSearchKeywordServiceTest.java
@@ -1,0 +1,83 @@
+package efub.assignment.community.Board.service;
+
+import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.board.dto.response.BoardSimpleResponse;
+import efub.assignment.community.board.repository.BoardRepository;
+import efub.assignment.community.board.repository.BoardSearchKeywordRepository;
+import efub.assignment.community.board.service.BoardSearchKeywordService;
+import efub.assignment.community.member.domain.Member;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+public class BoardSearchKeywordServiceTest {
+    @MockBean
+    private BoardRepository boardRepository;
+
+    @MockBean
+    private BoardSearchKeywordRepository keywordRepository;
+
+    @Autowired
+    private BoardSearchKeywordService boardSearchKeywordService;
+
+    @Test
+    void 게시판_이름_정확히_일치하면_검색된다(){
+        String keyword = "컴공벗들모여라";
+        Member member = Member.builder()
+                .email("test@email.com")
+                .nickname("nickname")
+                .studentId("studentId")
+                .university("University")
+                .build();
+        Board board = Board.builder()
+                .owner(member)
+                .name(keyword)
+                .notice("모이셈")
+                .description("description")
+                .build();
+        given(boardRepository.findByNameContaining(keyword))
+                .willReturn(List.of(board));
+        List<BoardSimpleResponse> result = boardSearchKeywordService.searchByName(keyword);
+
+        assertEquals(1, result.size());
+        assertEquals(keyword, result.get(0).getName());
+    }
+
+    @Test
+    void 검색어_일부_일치_시에도_반환한다(){
+        Member member = Member.builder()
+                .email("test@email.com")
+                .nickname("nickname")
+                .studentId("studentId")
+                .university("University")
+                .build();
+
+        Board board1 = Board.builder()
+                .owner(member)
+                .name("컴공벗들모여라")
+                .notice("공지")
+                .description("설명")
+                .build();
+
+        Board board2 = Board.builder()
+                .owner(member)
+                .name("컴공스터디")
+                .notice("공지")
+                .description("설명")
+                .build();
+        given(boardRepository.findByNameContaining("컴공"))
+                .willReturn(List.of(board1, board2));
+        List<BoardSimpleResponse> result = boardSearchKeywordService.searchByName("컴공");
+        assertEquals(2, result.size());
+        assertTrue(result.stream().anyMatch(b -> b.getName().equals("컴공벗들모여라")));
+        assertTrue(result.stream().anyMatch(b -> b.getName().equals("컴공스터디")));
+    }
+}


### PR DESCRIPTION
<!--
제목 예시: [이름] n주차 과제 제출
-->

## 📌 구현 기능  
- [x] 게시판 이름 검색

## 🗂️ 과제 정리  
### 기능 목표

- 사용자가 **게시판 이름**으로 검색할 수 있다.
- 검색어를 DB에 저장하여, 나중에 검색어 기록/추천에 활용 가능.
- 검색 기능은 부분 일치 지원.

### 엔티티 요구사항
검색어 기록을 저장하기 위한 엔티티
- 생성 시 검색어가 null이거나 빈 문자열이면 예외 발생

### 서비스 요구사항
게시판 이름 검색
- 입력: 검색어 (`String`)
- 출력: 게시판 리스트 (`게시판 id와 이름 담은 리스트`)

조건
- 부분 일치 가능

### 검색어 엔티티에 대한 테스트
<img width="2654" height="446" alt="image" src="https://github.com/user-attachments/assets/ee8c0643-0b4d-439a-9193-8ec8c663fc87" />

### 게시판 이름 검색 서비스 메서드에 대한 테스트
<img width="2642" height="474" alt="image" src="https://github.com/user-attachments/assets/c8b8b591-8778-42f8-9790-5f87418a04bc" />

