### PR TITLE
[김은솜] 11주차 과제 제출

### DIFF
--- a/community/src/main/java/com/efub/community/global/exception/ClientExceptionCode.java
+++ b/community/src/main/java/com/efub/community/global/exception/ClientExceptionCode.java
@@ -7,6 +7,7 @@ public enum ClientExceptionCode {
 
     // Account
     MEMBER_NOT_FOUND,
+    DUPLICATE_EMAIL,
 
     // Post
     POST_NOT_FOUND,

--- a/community/src/main/java/com/efub/community/global/exception/ExceptionCode.java
+++ b/community/src/main/java/com/efub/community/global/exception/ExceptionCode.java
@@ -16,6 +16,9 @@ public enum ExceptionCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.MEMBER_NOT_FOUND, "계정이 존재하지 않습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.POST_NOT_FOUND, "포스트가 존재하지 않습니다."),
 
+    // 409 Conflict
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, ClientExceptionCode.DUPLICATE_EMAIL, "이미 존재하는 이메일입니다."),
+
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ClientExceptionCode.INTERNAL_SERVER_ERROR, "예상치 못한 서버에러가 발생했습니다.");
 

--- a/community/src/main/java/com/efub/community/member/domain/entity/Member.java
+++ b/community/src/main/java/com/efub/community/member/domain/entity/Member.java
@@ -38,7 +38,7 @@ public class Member {
 
     // 회원 상태
     @Enumerated(EnumType.STRING)
-    private MemberStatus status; // = MemberStatus.ACTIVE; <-- 기본값 설정을 제거
+    private MemberStatus status = MemberStatus.ACTIVE;
 
     @Builder // setter 지양.
     public Member(String email, String password, String nickname, String university, String studentId) {

--- a/community/src/main/java/com/efub/community/member/domain/entity/Member.java
+++ b/community/src/main/java/com/efub/community/member/domain/entity/Member.java
@@ -38,7 +38,7 @@ public class Member {
 
     // 회원 상태
     @Enumerated(EnumType.STRING)
-    private MemberStatus status = MemberStatus.ACTIVE;
+    private MemberStatus status; // = MemberStatus.ACTIVE; <-- 기본값 설정을 제거
 
     @Builder // setter 지양.
     public Member(String email, String password, String nickname, String university, String studentId) {

--- a/community/src/main/java/com/efub/community/member/dto/CreateMemberRequestDto.java
+++ b/community/src/main/java/com/efub/community/member/dto/CreateMemberRequestDto.java
@@ -5,12 +5,16 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 // 회원가입 Request DTO
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class CreateMemberRequestDto {
 
     @NotBlank(message = "이메일은 필수 항목입니다.")

--- a/community/src/main/java/com/efub/community/member/service/MemberService.java
+++ b/community/src/main/java/com/efub/community/member/service/MemberService.java
@@ -28,15 +28,13 @@ public class MemberService {
 
     // 회원가입
     public CreateMemberResponseDto createMember(CreateMemberRequestDto requestDto) {
-        /*if(membersRepository.existsByEmail(requestDto.getEmail())) {
+        if(membersRepository.existsByEmail(requestDto.getEmail())) {
             throw new IllegalArgumentException("이미 존재하는 이메일입니다." + requestDto.getEmail());
         }
         Member member = requestDto.toEntity();
         Member saved = membersRepository.save(member);
 
-        return CreateMemberResponseDto.from(saved);*/
-
-        throw new UnsupportedOperationException("아직 구현되지 않은 기능입니다.");
+        return CreateMemberResponseDto.from(saved);
     }
 
     // 프로필(자기소개) 수정

--- a/community/src/main/java/com/efub/community/member/service/MemberService.java
+++ b/community/src/main/java/com/efub/community/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.efub.community.member.service;
 
+import com.efub.community.global.exception.BlogException;
+import com.efub.community.global.exception.ExceptionCode;
 import com.efub.community.member.domain.entity.Member;
 import com.efub.community.member.domain.entity.MemberStatus;
 import com.efub.community.member.dto.CreateMemberRequestDto;
@@ -28,8 +30,8 @@ public class MemberService {
 
     // 회원가입
     public CreateMemberResponseDto createMember(CreateMemberRequestDto requestDto) {
-        if(membersRepository.existsByEmail(requestDto.getEmail())) {
-            throw new IllegalArgumentException("이미 존재하는 이메일입니다." + requestDto.getEmail());
+        if (membersRepository.existsByEmail(requestDto.getEmail())) {
+            throw new BlogException(ExceptionCode.DUPLICATE_EMAIL);
         }
         Member member = requestDto.toEntity();
         Member saved = membersRepository.save(member);

--- a/community/src/main/java/com/efub/community/member/service/MemberService.java
+++ b/community/src/main/java/com/efub/community/member/service/MemberService.java
@@ -28,13 +28,15 @@ public class MemberService {
 
     // 회원가입
     public CreateMemberResponseDto createMember(CreateMemberRequestDto requestDto) {
-        if(membersRepository.existsByEmail(requestDto.getEmail())) {
+        /*if(membersRepository.existsByEmail(requestDto.getEmail())) {
             throw new IllegalArgumentException("이미 존재하는 이메일입니다." + requestDto.getEmail());
         }
         Member member = requestDto.toEntity();
         Member saved = membersRepository.save(member);
 
-        return CreateMemberResponseDto.from(saved);
+        return CreateMemberResponseDto.from(saved);*/
+
+        throw new UnsupportedOperationException("아직 구현되지 않은 기능입니다.");
     }
 
     // 프로필(자기소개) 수정

--- a/community/src/test/java/com/efub/community/member/domain/entity/MemberTest.java
+++ b/community/src/test/java/com/efub/community/member/domain/entity/MemberTest.java
@@ -1,0 +1,30 @@
+package com.efub.community.member.domain.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberTest {
+
+    @Test
+    @DisplayName("회원생성 시 기본상태(ACTIVE) 초기화 검증")
+    void member_default_status_test() {
+        // given
+        // Entity Builder를 통해 Member 객체 생성
+        Member member = Member.builder()
+                .email("test@lookup.com")
+                .password("pw")
+                .nickname("tester")
+                .university("Uni")
+                .studentId("1111")
+                .build();
+
+        // when
+        MemberStatus currentStatus = member.getStatus();
+
+        // then
+        // 현재 status는 null이므로, ACTIVE를 기대하는 이 코드는 반드시 실패
+        assertThat(currentStatus).isEqualTo(MemberStatus.ACTIVE);
+    }
+
+}

--- a/community/src/test/java/com/efub/community/member/service/MemberServiceTest.java
+++ b/community/src/test/java/com/efub/community/member/service/MemberServiceTest.java
@@ -1,0 +1,62 @@
+package com.efub.community.member.service;
+
+import com.efub.community.member.domain.entity.Member;
+import com.efub.community.member.dto.CreateMemberRequestDto;
+import com.efub.community.member.dto.CreateMemberResponseDto;
+import com.efub.community.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository membersRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("회원가입_성공_테스트")
+    void 회원_생성_성공() {
+        // given
+        CreateMemberRequestDto requestDto = mock(CreateMemberRequestDto.class);
+        given(requestDto.getEmail()).willReturn("test@example.com");
+
+        Member toSave = Member.builder()
+                .email("test@example.com")
+                .password("password")
+                .nickname("nick")
+                .university("uni")
+                .studentId("20250001")
+                .build();
+
+        given(requestDto.toEntity()).willReturn(toSave);
+        given(membersRepository.existsByEmail("test@example.com")).willReturn(false);
+
+        // save 시에 id가 세팅되었다고 시뮬레이션
+        given(membersRepository.save(any(Member.class))).willAnswer(invocation -> {
+            Member arg = invocation.getArgument(0);
+            ReflectionTestUtils.setField(arg, "memberId", 1L);
+            return arg;
+        });
+
+        // when
+        CreateMemberResponseDto responseDto = memberService.createMember(requestDto);
+
+        // then
+        assertThat(responseDto.getEmail()).isEqualTo("test@example.com");
+        assertThat(responseDto.getId()).isEqualTo(1L);
+        then(membersRepository).should(times(1)).existsByEmail("test@example.com");
+        then(membersRepository).should(times(1)).save(any(Member.class));
+    }
+}


### PR DESCRIPTION
## 📌 구현 기능  
- Member Entity과 MemberService의 핵심 로직에 대해 TDD 사이클(RED → GREEN → REFACTOR)을 적용

## 🗂️ 과제 정리   

### 1.  service에 대해 단위 테스트 

<img width="973" height="371" alt="image" src="https://github.com/user-attachments/assets/a2e17ed9-de6d-4410-a5e3-2043107effa2" />
실패한 테스트 결과를 위해, service에서 회원가입을 주석 처리

**[RED] 서비스 로직 주석처리 → 실패하는 테스트 코드**
`MemberService.createMember` 메서드가 `UnsupportedOperationException`을 던졌다
<img width="1728" height="856" alt="image" src="https://github.com/user-attachments/assets/ca9a2014-5154-4c12-bfa3-43422a2e24d7" />

**[GREEN]**

서비스 로직 주석 해제하자 테스트 통과
<img width="386" height="74" alt="image" src="https://github.com/user-attachments/assets/c43c1d0b-fe67-459d-b2c7-c2347504e4d8" />

**[REFACTOR]**

회원가입 로직은 사실 너무 간단해서 거의 수정할 게 없지만.. 이메일 중복 예외 처리에서 `IllegalArgumentException` 대신 이메일 중복 커스텀 예외를 만들어 명확한 예외 처리를 하도록 수정했다.

<img width="382" height="71" alt="image" src="https://github.com/user-attachments/assets/7c6ecd26-f79f-40eb-97f1-fad104f67545" />

---

### 2.  Entity(Domain)에 대해 단위 테스트 

<img width="747" height="86" alt="image" src="https://github.com/user-attachments/assets/216d1314-ee6a-4204-a316-368735d33098" />
실패한 테스트 결과를 위해, 멤버 상태 status 기본값 설정 제거

**[RED] 회원 상태가 NULL이라 테스트 실패**

<img width="1732" height="478" alt="image" src="https://github.com/user-attachments/assets/7237a9e8-5c87-4558-a1f9-87a228131b25" />**[GREEN]**

`= MemberStatus.ACTIVE;` 로직을 **복원**하여 테스트 통과

<img width="536" height="74" alt="image" src="https://github.com/user-attachments/assets/2910dc62-c428-43d0-b4d2-648ab83aba75" />

엔티티는 따로 리팩터할만한 내용이 거의 없어서.. refactor 단계는 생략했습니다 !

## ⚠️ 어려웠던 점
