### PR TITLE
[홍지형] 12주차 과제 제출

### DIFF
--- a/src/main/java/efub/assignment/community/member/dto/request/MemberRequestDto.java
+++ b/src/main/java/efub/assignment/community/member/dto/request/MemberRequestDto.java
@@ -1,14 +1,17 @@
 package efub.assignment.community.member.dto.request;
 
 import efub.assignment.community.member.domain.Member;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class MemberRequestDto {
 
     @NotBlank(message = "학번을 입력해주세요.")
@@ -25,6 +28,7 @@ public class MemberRequestDto {
 
     @NotBlank(message = "메일을 입력해주세요.")
     @Size(max = 100, message = "메일은 최대 100자까지 입력할 수 있습니다.")
+    @Email
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해주세요.")

--- a/src/main/java/efub/assignment/community/post/dto/request/PostCreateRequestDto.java
+++ b/src/main/java/efub/assignment/community/post/dto/request/PostCreateRequestDto.java
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.NotNull;
 public record PostCreateRequestDto(@NotNull Long boardId,
                                   @NotNull boolean anonymous,
                                   @NotNull Long authorId,
-                                  @NotBlank String content) {
+                                  @NotBlank(message = "게시물 내용을 입력해주세요.") String content) {
     public Post toEntity(Board board, Member author) {
         return Post.builder()
                 .board(board)

--- a/src/test/java/efub/assignment/community/member/MemberFixture.java
+++ b/src/test/java/efub/assignment/community/member/MemberFixture.java
@@ -1,0 +1,18 @@
+package efub.assignment.community.member;
+
+import efub.assignment.community.member.dto.request.MemberRequestDto;
+
+public class MemberFixture {
+
+    public static MemberRequestDto MEMBER_CREATE_REQUEST(){
+        return new MemberRequestDto(
+            "123456", "EwhaUniversity", "테스트닉", "test@test.com", "!123Abc123123456789"
+        );
+    }
+
+    public static MemberRequestDto MEMBER_CREATE_REQUEST_NICKNAME_TOO_LONG(){
+        return new MemberRequestDto(
+                "123456", "EwhaUniversity", "이건너무나도긴닉네임", "test@test.com", "!123Abc123123456789"
+        );
+    }
+}

--- a/src/test/java/efub/assignment/community/member/controller/MemberControllerTest.java
+++ b/src/test/java/efub/assignment/community/member/controller/MemberControllerTest.java
@@ -1,0 +1,72 @@
+package efub.assignment.community.member.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import efub.assignment.community.comment.repository.CommentRepository;
+import efub.assignment.community.member.MemberFixture;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.dto.request.MemberRequestDto;
+import efub.assignment.community.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class MemberControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("POST /members -> 201: 회원 생성 성공")
+    void createMember() throws Exception {
+        // given
+        MemberRequestDto createMemberRequest = MemberFixture.MEMBER_CREATE_REQUEST();
+
+        // when - then
+       mockMvc.perform(post("/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createMemberRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.studentId").value(createMemberRequest.getStudentId()))
+               .andExpect(jsonPath("$.university").value(createMemberRequest.getUniversity()))
+               .andExpect(jsonPath("$.nickname").value(createMemberRequest.getNickname()))
+               .andExpect(jsonPath("$.email").value(createMemberRequest.getEmail()));
+    }
+
+    @Test
+    @DisplayName("POST /members -> 400 : 긴 닉네임으로 인한 회원 생성 실패")
+    void createMember_tooLongNickName_Exception() throws Exception {
+        // given
+        MemberRequestDto tooLongNickNameRequest = MemberFixture.MEMBER_CREATE_REQUEST_NICKNAME_TOO_LONG();
+
+        // when then
+        mockMvc.perform(post("/members")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(tooLongNickNameRequest)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("닉네임은 1자 이상 8자 이하로 입력해주세요."))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.path").value("/members"));
+    }
+
+}

--- a/src/test/java/efub/assignment/community/member/controller/MemberControllerTest.java
+++ b/src/test/java/efub/assignment/community/member/controller/MemberControllerTest.java
@@ -62,7 +62,6 @@ class MemberControllerTest {
         mockMvc.perform(post("/members")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(tooLongNickNameRequest)))
-                .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("닉네임은 1자 이상 8자 이하로 입력해주세요."))
                 .andExpect(jsonPath("$.status").value(400))

--- a/src/test/java/efub/assignment/community/post/PostFixture.java
+++ b/src/test/java/efub/assignment/community/post/PostFixture.java
@@ -1,0 +1,20 @@
+package efub.assignment.community.post;
+
+import efub.assignment.community.post.dto.request.PostCreateRequestDto;
+
+public class PostFixture {
+
+    public static PostCreateRequestDto POST_CREATE_REQUEST(Long boardId, Long authorId){
+        return new PostCreateRequestDto(boardId,
+        false,
+        authorId,
+        "게시물 내용");
+    }
+
+    public static PostCreateRequestDto POST_CREATE_REQUEST_BLANK_CONTENT(Long boardId, Long authorId){
+        return new PostCreateRequestDto(boardId,
+                false,
+                authorId,
+                "");
+    }
+}

--- a/src/test/java/efub/assignment/community/post/controller/PostControllerTest.java
+++ b/src/test/java/efub/assignment/community/post/controller/PostControllerTest.java
@@ -1,0 +1,93 @@
+package efub.assignment.community.post.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.board.repository.BoardRepository;
+import efub.assignment.community.member.MemberFixture;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.dto.request.MemberRequestDto;
+import efub.assignment.community.member.repository.MemberRepository;
+import efub.assignment.community.post.PostFixture;
+import efub.assignment.community.post.dto.request.PostCreateRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class PostControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    BoardRepository boardRepository;
+    @Autowired
+    MemberRepository memberRepository;
+
+    Member createdMember;
+    Board createdBoard;
+
+    @BeforeEach
+    void setUp() {
+        // 초기 멤버 저장
+        MemberRequestDto createdMemberRequest = MemberFixture.MEMBER_CREATE_REQUEST();
+        createdMember = createdMemberRequest.toEntity();
+        memberRepository.save(createdMember);
+
+        // 초기 게시판 저장
+        createdBoard = new Board(createdMember, "게시판 설명", "게시판 공지", "게시판 이름");
+        boardRepository.save(createdBoard);
+    }
+
+    @DisplayName("POST /posts -> 201 : 게시물 생성 성공")
+    @Test
+    void createPost() throws Exception {
+        // given
+        PostCreateRequestDto createPostRequest = PostFixture.POST_CREATE_REQUEST(createdBoard.getBoardId(), createdMember.getMemberId());
+
+        // when then
+        mockMvc.perform(post("/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createPostRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.authorId").value(createPostRequest.authorId()))
+                .andExpect(jsonPath("$.anonymous").value(createPostRequest.anonymous()))
+                .andExpect(jsonPath("$.content").value(createPostRequest.content()))
+                .andExpect(jsonPath("$.createdAt").exists())
+                .andExpect(jsonPath("$.updatedAt").exists());
+    }
+
+    @DisplayName("POST /posts -> 400 : 빈 게시물 내용으로 인한 게시물 생성 실패")
+    @Test
+    void createPost_blankContent_Exception() throws Exception {
+        // given
+        PostCreateRequestDto createPostRequest = PostFixture.POST_CREATE_REQUEST_BLANK_CONTENT(createdBoard.getBoardId(), createdMember.getMemberId());
+
+        // when - then
+        mockMvc.perform(post("/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createPostRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("게시물 내용을 입력해주세요."))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.path").value("/posts"));
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,25 @@
+server:
+  port: 8080
+  servlet:
+    encoding:
+      charset: utf-8
+      force: true # 무슨일이 있어도 이렇게 인코딩하겠다
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MySQL # h2의 문법을 mysql로 맞추겠다.
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      '[hibernate.default_batch_fetch_size]': 100
+      '[hibernate.format_sql]': true
+    show-sql: true
+    output:
+      ansi:
+        enabled: always


### PR DESCRIPTION
<!--
제목 예시: [이름] n주차 과제 제출
-->

## 📌 구현 기능  
- [x] **Member Controller** 테스트
  - POST /members -> 201: 회원 생성 성공 
  - POST /members -> 400 : 긴 닉네임으로 인한 회원 생성 실패
- [x] **Post Controller** 테스트
  - POST /posts -> 201 : 게시물 생성 성공
  - POST /posts -> 400 : 빈 게시물 내용으로 인한 게시물 생성 실패

## 🗂️ 과제 정리  
### **Member Controller** 테스트
<img width="2652" height="384" alt="testtesttest" src="https://github.com/user-attachments/assets/5f1bf843-3b55-4858-8d72-8519fda9da9b" />

- MockMvc를 통한 멤버 생성에 관한 테스트를 진행했습니다.
- **정상적으로 멤버 생성이 된 경우**와 `@Valid`와 `@Size`에 의해 **닉네임이 8자 초과되어 멤버가 생성되지 못한 경우** 두 가지를 테스트했습니다.
- 실습 때에는 아래와 같이 String으로 body를 처리했는데 이렇게 작성하다 보니 따옴표를 빼먹는 등 단순 오타로 인하여 500이 반환되어 테스트가 실패하였고 이러한 인간이 행할 수 있는 실수를 최대한 줄일 수 있는 방식을 생각해보았습니다...
  - 왜냐면 요즘 제가 너무 오타를 많이 내기 때문입니다...😅😅
```
String body = """
                       {"studentId" : "1234567",
                       "university" : "hanguk"}
                      """
```
- 내부에서 생성자나 빌더패턴을 이용하여 요청DTO를 직접 생성하고자 했는데 고민해보니, 이러면 중복되는 코드가 늘어나고 가독성이 좋지 않은 것 같아 **`MemberFixture`에서 각각의 경우에 대한 DTO를 만들어서 반환**하는 방식으로 해보았습니다.
```
// 정상 생성 시 요청
MemberRequestDto createMemberRequest = MemberFixture.MEMBER_CREATE_REQUEST();

// 닉네임이 너무 긴 경우 요청
MemberRequestDto tooLongNickNameRequest = MemberFixture.MEMBER_CREATE_REQUEST_NICKNAME_TOO_LONG();
```
### **Post Controller** 테스트
<img width="2572" height="406" alt="화면 캡처 2025-10-04 181133" src="https://github.com/user-attachments/assets/7f57a4f5-79bf-4d9c-a2f5-49e8cb087aa3" />

* MockMvc를 통한 게시물 생성에 관한 테스트를 진행했습니다.
* - **정상적으로 게시물 생성이 된 경우**와 `@Valid`와 `@NotBlank`에 의해 **게시물 내용이 없어 생성되지 못한 경우** 두 가지를 테스트했습니다.
  * 기존에는 `@NotBlank`에 message 가 있지 않아서 추가해보았습니다.
* 앞의 테스트와 유사하게 `PostFixture`를 만들어서 DTO를 반환하는 형식으로 구성했습니다.
  * Post의 경우에는 생성 시 게시판과 작성자가 필요하여 이는 필드로 따로 뺀 후 `@BeforeEach`를 통해 테스트 실행 전 생성 및 저장하고 생성된 값을 파라미터로 넣어 DTO를 반환하게 했습니다.
```
// 정상적인 게시물 생성 DTO
PostCreateRequestDto createPostRequest = PostFixture.POST_CREATE_REQUEST(createdBoard.getBoardId(), createdMember.getMemberId());

// 게시물 내용이 없어서 생성이 안되는 DTO
PostCreateRequestDto createPostRequest = PostFixture.POST_CREATE_REQUEST_BLANK_CONTENT(createdBoard.getBoardId(), createdMember.getMemberId());
```
## ⚠️ 어려웠던 점  
```
mockMvc.perform(post("/posts")
                        .contentType(MediaType.APPLICATION_JSON)
                        .content(objectMapper.writeValueAsString(createPostRequest)))
                .andExpect(status().isCreated())
                .andExpect(jsonPath("$.authorId").value(createPostRequest.authorId()))
                .andExpect(jsonPath("$.anonymous").value(createPostRequest.anonymous()))
                .andExpect(jsonPath("$.content").value(createPostRequest.content()))
                .andExpect(jsonPath("$.createdAt").exists())
                .andExpect(jsonPath("$.updatedAt").exists());
```
- 이 부분에서 `jsonPath`를 통해 json에서 각각의 값을 접근하는 방식에서 `"$.authorId"` 이렇게 사람이 직접 적어야되는지 의문이 들었습니다.
- 실제로 작성하다가 nickname이라고 적어야 되는데 nickName이라고 작성하여 테스트 실패하기도 하여 이를 해결할 수 있는 방안을 고민 중입니다!
