### PR TITLE
[양은서] 12주차 과제 제출

### DIFF
--- a/community/build.gradle
+++ b/community/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 
 	implementation 'com.mysql:mysql-connector-j:8.0.33'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    testImplementation 'com.h2database:h2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }
 
 tasks.named('test') {

--- a/community/src/main/java/efub/assignment/community/global/exception/dto/ClientExceptionCode.java
+++ b/community/src/main/java/efub/assignment/community/global/exception/dto/ClientExceptionCode.java
@@ -22,5 +22,8 @@ public enum ClientExceptionCode {
 
     // CommentLike
     LIKE_NOT_FOUND,
-    LIKE_ALREADY_EXISTS
+    LIKE_ALREADY_EXISTS,
+
+    // Member
+    MEMBER_NOT_FOUND,
 }

--- a/community/src/main/java/efub/assignment/community/global/exception/dto/ExceptionCode.java
+++ b/community/src/main/java/efub/assignment/community/global/exception/dto/ExceptionCode.java
@@ -18,6 +18,7 @@ public enum ExceptionCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.POST_NOT_FOUND, "포스트가 존재하지 않습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.COMMENT_NOT_FOUND, "댓글이 존재하지 않습니다."),
     LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.LIKE_NOT_FOUND, "댓글 좋아요가 존재하지 않습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.MEMBER_NOT_FOUND, "멤버가 존재하지 않습니다."),
 
     // 409 Conflict
     LIKE_ALREADY_EXISTS(HttpStatus.CONFLICT, ClientExceptionCode.LIKE_ALREADY_EXISTS, "이미 좋아요를 누르셨습니다."),

--- a/community/src/test/java/efub/assignment/community/member/controller/MemberControllerTest.java
+++ b/community/src/test/java/efub/assignment/community/member/controller/MemberControllerTest.java
@@ -1,0 +1,72 @@
+package efub.assignment.community.member.controller;
+
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class MemberControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    MemberRepository memberRepository;
+
+    private Long savedMemberId;
+
+    @BeforeEach
+    void seed() {
+        Member member = new Member("yepot@email.com", "testpw", "yepot", "ewha", 2371040L);
+        savedMemberId = memberRepository.save(member).getMemberId();
+    }
+
+    @Test
+    @DisplayName("GET /members/{memberId} → 멤버 조회 성공 시 200 OK와 JSON 반환")
+    void getMember_success() throws Exception {
+        mockMvc.perform(
+                        get("/members/{memberId}", savedMemberId)
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.memberId").value(Math.toIntExact(savedMemberId)))
+                .andExpect(jsonPath("$.nickname").value("yepot"))
+                .andExpect(jsonPath("$.email").value("yepot@email.com"))
+                .andExpect(jsonPath("$.studentId").value(2371040))
+                .andExpect(jsonPath("$.university").value("ewha"));
+    }
+
+    @Test
+    @DisplayName("GET /members/{memberId} → 존재하지 않는 멤버면 500 & IllegalArgumentException (현재 동작 기준)")
+    void getMember_notFound_returns500_illegalArgument() throws Exception {
+        Long nonExistingId = (savedMemberId == null ? 999999L : savedMemberId + 9999);
+
+        mockMvc.perform(get("/members/{memberId}", nonExistingId)
+                                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError())
+                .andExpect(result -> {Throwable ex = result.getResolvedException();
+                   assertThat(ex).isInstanceOf(IllegalArgumentException.class);
+                   assertThat(ex.getMessage()).contains("해당 멤버를 찾을 수 없습니다.");
+                });
+    }
+
+
+
+
+}

--- a/community/src/test/java/efub/assignment/community/post/controller/PostControllerTest.java
+++ b/community/src/test/java/efub/assignment/community/post/controller/PostControllerTest.java
@@ -1,0 +1,99 @@
+package efub.assignment.community.post.controller;
+
+import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.board.repository.BoardRepository;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.repository.MemberRepository;
+import efub.assignment.community.post.domain.Post;
+import efub.assignment.community.post.repository.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class PostControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    MemberRepository accountsRepository;
+    @Autowired
+    PostRepository postRepository;
+    @Autowired
+    BoardRepository boardRepository;
+
+    private Member writer;
+    private Board savedBoard;
+    private Post post;
+
+    @BeforeEach
+    void seed() throws Exception {
+        writer = accountsRepository.save(new Member("yepot@email.com", "testpw", "yepot", "ewha", 2371040L));
+        savedBoard = boardRepository.save(Board.builder()
+                        .boardName("boardName")
+                        .description("자유 게시판")
+                        .notice("공지입니다")
+                        .owner(writer)
+                        .build());
+        Post tmp = Post.builder()
+                .writer(writer)
+                .content("원본 내용은 다섯글자 이상")
+                .anonymous(false)
+                .build();
+
+        Field f = Post.class.getDeclaredField("board");
+        f.setAccessible(true);
+        f.set(tmp, savedBoard);
+
+        post = postRepository.save(tmp);
+    }
+
+    @Test
+    @DisplayName("PATCH /posts/{postId} → 204 No Content & DB 내용 변경 확인 (내용수정 성공)")
+    void updatePost_success_204() throws Exception {
+        // given
+        String body = """
+            {"content":"수정된 내용은 다섯글자 이상"}
+            """;
+
+        // when then
+        mockMvc.perform(patch("/posts/{postId}", post.getId())
+                                .header("Auth-Id", writer.getMemberId())
+                                .header("Auth-Password", writer.getPassword())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body))
+                .andExpect(status().isNoContent());
+
+        Post updated = postRepository.findById(post.getId()).orElseThrow();
+        assertEquals("수정된 내용은 다섯글자 이상", updated.getContent());
+    }
+
+    @Test
+    @DisplayName("DELETE /posts/{postId} → 비밀번호 불일치로 삭제 실패 (POST_ACCOUNT_MISMATCH)")
+    void deletePost_fail_accountMismatch() throws Exception {
+
+        // when then
+        mockMvc.perform(delete("/posts/{postId}", post.getId())
+                                .header("Auth-Id", writer.getMemberId())
+                                .header("Auth-Password", "wrong-password"))
+                .andExpect(status().isUnauthorized());
+
+        assertTrue(postRepository.findById(post.getId()).isPresent());
+    }
+}

--- a/community/src/test/resources/application-test.yml
+++ b/community/src/test/resources/application-test.yml
@@ -1,0 +1,25 @@
+server:
+  port: 8080
+  servlet:
+    encoding:
+      charset: utf-8
+      force: true # 무슨일이 있어도 이렇게 인코딩하겠다
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MySQL # h2의 문법을 mysql로 맞추겠다.
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      '[hibernate.default_batch_fetch_size]': 100
+      '[hibernate.format_sql]': true
+    show-sql: true
+    output:
+      ansi:
+        enabled: always

--- a/community/src/test/resources/data.sql
+++ b/community/src/test/resources/data.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS member (
+    member_id BIGINT NOT NULL AUTO_INCREMENT,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    nickname VARCHAR(50) NOT NULL,
+    university VARCHAR(100) NOT NULL,
+    student_id BIGINT NOT NULL,
+    status VARCHAR(50) DEFAULT 'ACTIVE',
+    PRIMARY KEY (member_id)
+);
+
+


### PR DESCRIPTION
## 📌 구현 기능  
- PostControllerTest
  - [x] 게시글 수정 성공 테스트
  - [x] 게시글 삭제 실패 테스트
- MemberControllerTest
  - [x] 회원 조회 성공 테스트
  - [x] 회원 조회 실패 테스트

## 🗂️ 과제 정리  
### PostControllerTest
- 게시글 수정 성공 테스트 : PATCH /posts/{postId} → 204 No Content & DB 내용 변경 확인 (내용수정 성공)
    <img width="1349" height="467" alt="image" src="https://github.com/user-attachments/assets/9d5b6334-74e9-4b06-9040-96a515d5c3d0" />

- 게시글 삭제 실패 테스트 : DELETE /posts/{postId} → 비밀번호 불일치로 삭제 실패 (POST_ACCOUNT_MISMATCH)
  <img width="1350" height="257" alt="image" src="https://github.com/user-attachments/assets/5e193e23-df29-4717-8d8c-afe4a0ad6c83" />

### MemberControllerTest
- 회원 조회 성공 테스트 : GET /members/{memberId} → 멤버 조회 성공 시 200 OK와 JSON 반환
  <img width="1343" height="485" alt="image" src="https://github.com/user-attachments/assets/48594d97-d75f-4b7e-ada3-f9d3e6d23bb7" />

- 회원 조회 실패 테스트 : GET /members/{memberId} → 존재하지 않는 멤버면 500 & IllegalArgumentException (현재 동작 기준)
  <img width="1339" height="488" alt="image" src="https://github.com/user-attachments/assets/6c2e486f-e2ab-44c5-9116-1bb3dda63d7c" />


## ⚠️ 어려웠던 점  
- 데이터 시드를 어느 정도까지 넣어야 적절한지 애매했다..
