### PR TITLE
[홍지형] 13주차 / 15주차 과제 제출

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
+ext {
+	queryDslVersion = "5.0.0"
+}
+
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
@@ -17,6 +21,7 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
+	querydsl.extendsFrom compileClasspath
 }
 
 repositories {
@@ -40,6 +45,33 @@ dependencies {
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt:0.12.6'
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
+	// querydsl
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+	main {
+		java {
+			srcDirs += [querydslDir]
+		}
+	}
+}
+
+tasks.named('compileJava') {
+	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+tasks.named('compileTestJava') {
+	options.compilerArgs += ['-proc:none'] // 테스트용 컴파일에선 APT 비활
+}
+
+clean.doLast {
+	file(querydslDir).deleteDir()
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,13 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	/* OAuth2 */
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt:0.12.6'
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/efub/assignment/community/global/config/QueryDslConfig.java
+++ b/src/main/java/efub/assignment/community/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package efub.assignment.community.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/efub/assignment/community/global/config/RedisConfig.java
+++ b/src/main/java/efub/assignment/community/global/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package efub.assignment.community.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching // 캐싱 기능 활성화
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+
+}

--- a/src/main/java/efub/assignment/community/global/config/SecurityConfig.java
+++ b/src/main/java/efub/assignment/community/global/config/SecurityConfig.java
@@ -1,0 +1,83 @@
+package efub.assignment.community.global.config;
+
+import efub.assignment.community.global.jwt.JwtAuthenticationFilter;
+import efub.assignment.community.global.jwt.TokenProvider;
+import efub.assignment.community.handler.OAuth2AuthenticationSuccessHandler;
+import efub.assignment.community.member.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final TokenProvider tokenProvider;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    /**
+     * SecurityFilterChain 설정을 위한 Bean 등록
+     * HTTP 요청에 대한 보안 구성을 정의하고, JWT 인증 필터 추가
+     */
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, CorsConfigurationSource corsConfigurationSource) throws Exception {
+        return http
+                // 기본 인증 방식 비활성화 (UI 대신 토큰을 통한 인증을 사용하기 때문)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                // CSRF 보호 비활성화 (토큰 기반 인증이므로 필요하지 않음)
+                .csrf(AbstractHttpConfigurer::disable)
+                //cors 설정 추가
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                // 요청에 따른 인증 인가 설정
+                .authorizeHttpRequests(request ->{
+                    request.requestMatchers("/**").permitAll();
+                    request.anyRequest().authenticated();
+                })
+                // JWT를 사용하므로 sateless
+                .sessionManagement(
+                        sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                // JWT 인증 필터를 UsernamePAsswordAuthenticationFilter 앞에 추가하여 JWT를 통한 인증 수행
+                .addFilterBefore(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+                // OAuth2 로그인 설정 - 인증된 사용자 정보(프로필)를 가져오는 방식 정의, 인증 성공시 동작을 정의하는 successHandler 설정
+                .oauth2Login(oauth2 -> oauth2.userInfoEndpoint(userInfo
+                                -> userInfo.userService(customOAuth2UserService))
+                        .successHandler(oAuth2AuthenticationSuccessHandler)
+                ).build();
+
+    }
+    // ============== [ CORS 설정 Bean 추가 ] ==============
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        // 1. 허용할 출처(프론트엔드)를 명시
+        configuration.addAllowedOrigin("http://localhost:3000");
+
+        // 2. 허용할 HTTP 메서드(GET, POST 등)를 명시
+        configuration.addAllowedHeader("*");
+
+        // 3. 허용할 HTTP 헤더를 명시
+        configuration.addAllowedMethod("*");
+
+        // 4. 자격 증명(쿠키, 인증 헤더 등)을 허용할지 여부를 설정
+        // true로 설정해야 Authorization 헤더에 담긴 JWT 토큰을 주고받기 가능
+        configuration.setAllowCredentials(true);
+
+        // 모든 경로(/)에 대해 위에서 정의한 CORS 설정을 적용
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+        // ===============================================
+    }
+}

--- a/src/main/java/efub/assignment/community/global/config/SecurityConfig.java
+++ b/src/main/java/efub/assignment/community/global/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 // 요청에 따른 인증 인가 설정
                 .authorizeHttpRequests(request ->{
+                    request.requestMatchers(HttpMethod.GET).permitAll();
                     request.requestMatchers("/**").permitAll();
                     request.anyRequest().authenticated();
                 })

--- a/src/main/java/efub/assignment/community/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/efub/assignment/community/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package efub.assignment.community.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final TokenProvider tokenProvider;
+
+    private static final String BEARER = "Bearer ";
+    private static final String HEADER = "Authorization";
+
+    /**
+     * JWT 인증 필터
+     *
+     * HTTP 요청을 가로채 JWT 토큰을 검사하고, 유효한 경우 인증 정보를 설정
+     */
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorizationHeader = request.getHeader(HEADER);
+
+        String token = getAccessToken(authorizationHeader);
+
+        if(!ObjectUtils.isEmpty(token) && tokenProvider.isValidToken(token)) {
+            Authentication auth = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Authorization 헤더에서 Bearer 접두사를 제거해 토큰 추출
+     */
+    private String getAccessToken(String authorizationHeader){
+        // Token이 null이 아니고 Bearer로 시작해야지 정상적인 Token
+        if(authorizationHeader != null && authorizationHeader.startsWith(BEARER)){
+            // 정상적인 토큰이라면 앞에 Bearer 제거 후 리턴
+            return authorizationHeader.substring(BEARER.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/efub/assignment/community/global/jwt/TokenProvider.java
+++ b/src/main/java/efub/assignment/community/global/jwt/TokenProvider.java
@@ -1,0 +1,138 @@
+package efub.assignment.community.global.jwt;
+
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.repository.MemberRepository;
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenProvider {
+
+    // application.yml에 저장한 jwt값 가져오기
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+
+    // 토큰 만료시간 설정
+    private static final Long accessTokenExpiration = 1000*60*60L;
+    private static final Long refreshTokenExpiration = 1000*60*60*24*14L;
+
+    // 토큰에 포함할 기본 정보와 클레임 키값 설정
+    private static final String AUTH_CLAIM = "auth";
+
+    private final MemberRepository memberRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * AccessToken 생성 메소드
+     * 사용자 이메일 정보를 포함해 AccessToken 생성
+     */
+    public String createAccessToken(Member member){
+        Date now = new Date();
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + accessTokenExpiration))
+                .setSubject(member.getEmail())
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    /**
+     * RefreshToken 생성 메소드
+     */
+    public String createRefreshToken(Member member){
+        Date now = new Date();
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + refreshTokenExpiration))
+                .setSubject(member.getEmail())
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    /**
+     * Redis에 리프레시 토큰을 저장하는 메소드
+     * key: 사용자 ID, alue: 리프레시 토큰
+     * 리프레시토큰 만료 시간(refreshTokenExpiration)을 만료시간으로 정해 자동으로 삭제되도록 설정
+     */
+    public void saveRefreshToken(Long userId, String refreshToken){
+        redisTemplate.opsForValue().set(userId.toString(), refreshToken, Duration.ofMillis(refreshTokenExpiration));
+    }
+
+    /**
+     * AccessToken에서 email 추출
+     * 토큰이 유효한지 확인 후 이메일 클레임 값을 추출
+     */
+    public String extractEmail(String accessToken){
+        if(isValidToken(accessToken)){
+            return getClaims(accessToken).getSubject();
+        }
+        return null;
+    }
+
+    /**
+     * 유효한 토큰인지 검증
+     */
+    public boolean isValidToken(String token){
+        try{
+            // secretKey를 사용해 토큰 복호화
+            Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            log.info("Validate token success");
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty", e);
+        }
+        return false;
+    }
+
+    /**
+     * 토큰에서 사용자 인증 정보를 꺼내 반환
+     * JWT 토큰의 클레임에서 사용자 이메일과 권한 정보를 추출하여 Authentication 객체를 생성
+     */
+    public Authentication getAuthentication(String token){
+        // 토큰 복호화
+        Claims claims = getClaims(token);
+
+        // 토큰에서 정보를 꺼냄
+        Set<SimpleGrantedAuthority> authorities = Collections
+                .singleton(new SimpleGrantedAuthority("ROLE_USER"));
+
+        return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails
+                .User(claims.getSubject(), "", authorities), token, authorities);
+    }
+
+    /**
+     * 토큰을 복호화한 후 페이로드 반환
+     */
+    private Claims getClaims(String token){
+        return Jwts.parser()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/efub/assignment/community/global/utils/OAuth2UserInfo.java
+++ b/src/main/java/efub/assignment/community/global/utils/OAuth2UserInfo.java
@@ -1,0 +1,27 @@
+package efub.assignment.community.global.utils;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Map;
+
+@AllArgsConstructor
+public class OAuth2UserInfo {
+    private Map<String, Object> attributes;
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public String getEmail() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        return kakaoAccount != null ? (String) kakaoAccount.get("email") : null;
+    }
+
+    public String getNickname() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        if (kakaoAccount == null) return null;
+
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        return profile != null ? (String) profile.get("nickname") : null;
+    }
+}

--- a/src/main/java/efub/assignment/community/global/utils/SecurityUtils.java
+++ b/src/main/java/efub/assignment/community/global/utils/SecurityUtils.java
@@ -1,0 +1,16 @@
+package efub.assignment.community.global.utils;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtils {
+
+    public static String getCurrentUserEmail(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if(authentication == null || authentication.getName() == null){
+            return null;
+        }
+        return authentication.getName();
+    }
+}

--- a/src/main/java/efub/assignment/community/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/efub/assignment/community/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,50 @@
+package efub.assignment.community.handler;
+
+import efub.assignment.community.global.jwt.TokenProvider;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.repository.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+    private final String redirectUri = "http://localhost:8080/callback";
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest httpServletRequest, HttpServletResponse response, Authentication authentication) throws IOException {
+        DefaultOAuth2User oAuth2User = (DefaultOAuth2User) authentication.getPrincipal();
+
+        String email = (String) oAuth2User.getAttributes().get("email");
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("해당 email을 가진 Account를 찾을 수 없습니다."));
+
+        String accessToken = tokenProvider.createAccessToken(member);
+        String refreshToken = tokenProvider.createRefreshToken(member);
+
+        tokenProvider.saveRefreshToken(member.getMemberId(), refreshToken);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+
+        String jsonResponse = String.format("{\"access_token\":\"%s\", \"refresh_token\":\"%s\"}", accessToken, refreshToken);
+        response.getWriter().write(jsonResponse);
+        response.getWriter().flush();
+    }
+
+
+}

--- a/src/main/java/efub/assignment/community/member/controller/AuthController.java
+++ b/src/main/java/efub/assignment/community/member/controller/AuthController.java
@@ -1,0 +1,33 @@
+package efub.assignment.community.member.controller;
+
+import efub.assignment.community.global.utils.SecurityUtils;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.dto.request.TokenRequestDto;
+import efub.assignment.community.member.dto.response.TokenResponseDto;
+import efub.assignment.community.member.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    //현재 인증된 사용자 이메일 조회
+    @GetMapping("/me")
+    public ResponseEntity<String> getEmail(){
+        return ResponseEntity.ok(SecurityUtils.getCurrentUserEmail());
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenResponseDto> reissue(@RequestBody TokenRequestDto requestDto) {
+        return ResponseEntity.ok(
+                authService.reissueAccessToken(requestDto.getRefreshToken())
+        );
+    }
+
+}

--- a/src/main/java/efub/assignment/community/member/domain/Member.java
+++ b/src/main/java/efub/assignment/community/member/domain/Member.java
@@ -24,15 +24,15 @@ public class Member extends BaseEntity {
     private Long memberId;
 
     // 학번
-    @Column (nullable = false, length = 20, unique = true)
+    @Column (nullable = true, length = 20, unique = true)
     private String studentId;
 
     // 대학
-    @Column (nullable = false, length = 100)
+    @Column (nullable = true, length = 100)
     private String university;
 
     // 닉네임
-    @Column (nullable = false, length = 8)
+    @Column (nullable = false)
     private String nickname;
 
     // 이메일

--- a/src/main/java/efub/assignment/community/member/dto/request/TokenRequestDto.java
+++ b/src/main/java/efub/assignment/community/member/dto/request/TokenRequestDto.java
@@ -1,0 +1,8 @@
+package efub.assignment.community.member.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class TokenRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/efub/assignment/community/member/dto/response/TokenResponseDto.java
+++ b/src/main/java/efub/assignment/community/member/dto/response/TokenResponseDto.java
@@ -1,0 +1,18 @@
+package efub.assignment.community.member.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TokenResponseDto {
+
+    private String accessToken;
+
+    @Builder
+    public TokenResponseDto(final String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/efub/assignment/community/member/repository/MemberRepository.java
+++ b/src/main/java/efub/assignment/community/member/repository/MemberRepository.java
@@ -12,4 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
     // 멤버 ID로 조회
     Optional<Member> findByMemberId(Long memberId);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/efub/assignment/community/member/service/AuthService.java
+++ b/src/main/java/efub/assignment/community/member/service/AuthService.java
@@ -1,0 +1,45 @@
+package efub.assignment.community.member.service;
+
+import efub.assignment.community.global.jwt.TokenProvider;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.dto.response.TokenResponseDto;
+import efub.assignment.community.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * AccessToken 재발급
+     *
+     * 클라이언트가 전달한 리프레시 토큰을 검증해 유효한 경우 새로운 액세스토큰을 발급한다.
+     */
+    public TokenResponseDto reissueAccessToken(String refreshToken){
+        // 전달받은 리프레시 토큰에서 이메일을 추출하여 사용자 정보 가져오기
+        String email = tokenProvider.extractEmail(refreshToken);
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("해당 이메일로 사용자를 찾을 수 없습니다."));
+
+        // Redis에서 해당 사용자 Id를 키로 하는 리프레시 토큰 가져오기
+        String storedRefreshToken = redisTemplate.opsForValue().get(member.getMemberId().toString());
+
+        // 전달받은 리프레시 토큰과 Redis에 저장된 리프레시 토큰이 일치하는지 확인
+        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)){
+            throw new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다.");
+        }
+
+        // 일치한다면 새로운 AccessToken 생성
+        String accessToken = tokenProvider.createAccessToken(member);
+
+        return TokenResponseDto.builder()
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/src/main/java/efub/assignment/community/member/service/CustomOAuth2UserService.java
+++ b/src/main/java/efub/assignment/community/member/service/CustomOAuth2UserService.java
@@ -1,0 +1,59 @@
+package efub.assignment.community.member.service;
+
+import efub.assignment.community.global.utils.OAuth2UserInfo;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final MemberRepository memberRepository;
+
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = new DefaultOAuth2UserService().loadUser(userRequest);
+
+        OAuth2UserInfo oAuth2UserInfo = new OAuth2UserInfo(oAuth2User.getAttributes());
+
+        Member member = memberRepository.findByEmail(oAuth2UserInfo.getEmail())
+                .orElseGet(() -> createAccount(oAuth2UserInfo));
+
+        Map<String, Object> attributes = new HashMap<>(oAuth2User.getAttributes());
+
+        attributes.put("id", member.getMemberId());
+        attributes.put("email", member.getEmail());
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new OAuth2UserAuthority(attributes)),
+                attributes, "email"
+        );
+    }
+    /**
+     * 사용자 생성 메서드
+     *
+     * OAuth2로그인은 비밀번호가 필요하지 않으므로 ""
+     */
+    private Member createAccount(OAuth2UserInfo oAuth2UserInfo) {
+        Member member = Member.builder()
+                .email(oAuth2UserInfo.getEmail())
+                .password("")
+                .nickname(oAuth2UserInfo.getNickname())
+                .build();
+        return memberRepository.save(member);
+    }
+
+}

--- a/src/main/java/efub/assignment/community/post/controller/PostController.java
+++ b/src/main/java/efub/assignment/community/post/controller/PostController.java
@@ -13,6 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/posts")
@@ -47,6 +49,13 @@ public class PostController {
     public ResponseEntity<PostListResponseDto> getPosts(@PathVariable Long boardId) {
         PostListResponseDto postListResponseDto = postService.getPostList(boardId);
         return ResponseEntity.status(HttpStatus.OK).body(postListResponseDto);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<PostResponseDto>> searchPost(
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "writer", required = false) String writerNickname) {
+        return ResponseEntity.ok(postService.searchPost(keyword, writerNickname));
     }
 
     // 게시글 삭제

--- a/src/main/java/efub/assignment/community/post/repository/CustomPostRepository.java
+++ b/src/main/java/efub/assignment/community/post/repository/CustomPostRepository.java
@@ -1,0 +1,10 @@
+package efub.assignment.community.post.repository;
+
+import efub.assignment.community.post.domain.Post;
+
+import java.util.List;
+
+public interface CustomPostRepository {
+
+    List<Post> search(String keyword, String writerNickname);
+}

--- a/src/main/java/efub/assignment/community/post/repository/CustomPostRepositoryImpl.java
+++ b/src/main/java/efub/assignment/community/post/repository/CustomPostRepositoryImpl.java
@@ -1,0 +1,39 @@
+package efub.assignment.community.post.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import efub.assignment.community.member.domain.QMember;
+import efub.assignment.community.post.domain.Post;
+import efub.assignment.community.post.domain.QPost;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomPostRepositoryImpl implements CustomPostRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Post> search(String keyword, String writerNickname){
+        QPost post = QPost.post;
+        QMember member = QMember.member;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if(writerNickname != null && !writerNickname.isBlank()){
+            builder.and(post.author.nickname.eq(writerNickname));
+        }
+
+        if(keyword != null && !keyword.isBlank()){
+            builder.and(post.content.containsIgnoreCase(keyword));
+        }
+
+        return queryFactory.selectFrom(post)
+                .join(post.author, member).fetchJoin()
+                .where(builder)
+                .orderBy(post.createdAt.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/efub/assignment/community/post/repository/PostRepository.java
+++ b/src/main/java/efub/assignment/community/post/repository/PostRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, CustomPostRepository {
     Optional<Post> findByPostId(Long postId);
 
     void deleteByPostId(Long postId);

--- a/src/main/java/efub/assignment/community/post/service/PostService.java
+++ b/src/main/java/efub/assignment/community/post/service/PostService.java
@@ -64,6 +64,14 @@ public class PostService {
         return PostListResponseDto.from(boardId, postList);
     }
 
+    // 글쓴이, 내용으로 게시물 조회
+    @Transactional(readOnly = true)
+    public List<PostResponseDto> searchPost(String keyword, String writerNickname) {
+        return postRepository.search(keyword, writerNickname).stream()
+                .map(PostResponseDto::from)
+                .toList();
+    }
+
     // 게시글 삭제
     @Transactional
     public void deletePost(Long postId) {


### PR DESCRIPTION
<!--
제목 예시: [이름] n주차 과제 제출
-->
# 13주차
## 📌 구현 기능  
- [x] JWT 구현
- [x] 카카오 로그인 구현

## 🗂️ 과제 정리  
- 카카오 로그인 구현
<img width="2434" height="246" alt="image" src="https://github.com/user-attachments/assets/fcb63b00-9f01-450c-b665-11c46cb339fe" />

## ⚠️ 어려웠던 점  
<img width="1166" height="536" alt="image" src="https://github.com/user-attachments/assets/3c4f0a1a-a3b8-4d1d-bd66-70d0df5f9f17" />

- OAuth2 방식으로 구현할 때, 카카오 디벨로퍼스에서 허용 IP에 WAN 주소를 입력해야 401 에러가 발생하지 않았습니다.  
  하지만 저는 이동이 잦은 환경에서 개발하다 보니 매번 [나의 IPv4 주소](https://whatismyipaddress.com/)를 확인하고 입력해야 하는 번거로움이 있었습니다.
<img width="1010" height="582" alt="image" src="https://github.com/user-attachments/assets/3cbca909-f251-4e53-ba36-7b4f6cdd668d" />

- 이전에 사용하던 방식
```
1. 프론트엔드에서 카카오 로그인 버튼을 누르면 인가 코드(code)를 받음.
2. 프론트에서 받은 코드를 백엔드로 전달.
3. 백엔드에서 카카오 서버로 토큰 발급 요청 → access token, refresh token 획득.
4. 백엔드에서 카카오 서버로 사용자 정보 요청 → 로그인 처리
```

- 이전 방식과 비교하면, 백엔드에서 카카오 서버로 API 요청하는 부분이 자동으로 처리되어 편리하지만,  
  개발 환경이 달라질 때는 조금 불편하게 느껴질 수 있습니다.  
- 다만, 배포 환경에서는 IP가 고정되고 개발 환경도 일정하게 유지되므로, 이러한 불편은 크게 문제되지 않습니다...ㅎㅎ

# 15주차
## 📌 구현 기능  
- [x] queryDsl로 글쓴이, 키워드를 통한 게시물 조회

## 🗂️ 과제 정리  
1. 키워드 "위시" 지정 시, 게시물 내용에 위시가 포함된 게시물 반환
<img width="2596" height="1406" alt="image" src="https://github.com/user-attachments/assets/e14b8590-c047-4e9a-8378-93971fcea55c" />

2. 글쓴이 "사쿠야" 지정 시, 닉네임이 사쿠야이고 member id = 3인 회원이 쓴 게시물 반환
<img width="2258" height="1386" alt="사쿠사쿠" src="https://github.com/user-attachments/assets/c331862d-759e-4c4b-9cab-e32b8f223a98" />

3. 글쓴이 "사쿠야" + 키워드 "사쿠" -> 사쿠야가 썼는데 사쿠가 들어간 게시물 반환
<img width="2600" height="1168" alt="사쿠" src="https://github.com/user-attachments/assets/17016eab-1217-4056-9369-7a1d7c52eedb" />
