### PR TITLE
[복지희] 15주차 과제 제출

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,36 @@ dependencies {
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 	/* OAuth2 */
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	//QueryDsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
+
+ // QueryDSL 실습용 생성 경로
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+sourceSets {
+ 	main {
+ 		java {
+			srcDir layout.buildDirectory.dir("generated/querydsl").get()
+ 		}
+ 	}
+ }
+
+ tasks.named('compileJava') {
+ 	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+ }
+
+ tasks.named('compileTestJava') {
+ 	options.compilerArgs += ['-proc:none'] // 테스트용 컴파일에선 APT 비활성화
+ }
+
+ clean.doLast {
+ 	file(querydslDir).deleteDir()
+ }
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -34,6 +36,14 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'com.h2database:h2'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	/* jwt */
+	implementation 'io.jsonwebtoken:jjwt:0.12.6'
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
+	/* OAuth2 */
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/efub/assignment/community/auth/controller/AuthController.java
+++ b/src/main/java/efub/assignment/community/auth/controller/AuthController.java
@@ -27,7 +27,7 @@ public class AuthController {
     }
 
     @GetMapping("/kakao")
-    public ResponseEntity<String> kakaoLogin(@RequestParam String code) {
+    public ResponseEntity<TokenResponseDto> kakaoLogin(@RequestParam String code) {
         return ResponseEntity.ok(kakaoService.kakaoLogin(code));
     }
 }

--- a/src/main/java/efub/assignment/community/auth/controller/AuthController.java
+++ b/src/main/java/efub/assignment/community/auth/controller/AuthController.java
@@ -1,0 +1,33 @@
+package efub.assignment.community.auth.controller;
+
+import efub.assignment.community.auth.dto.response.TokenResponseDto;
+import efub.assignment.community.auth.service.AuthService;
+import efub.assignment.community.auth.service.KakaoService;
+import efub.assignment.community.global.utils.SecurityUtils;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+    private final KakaoService kakaoService;
+
+    //현재 인증된 사용자 이메일 조회
+    @GetMapping("/me")
+    public ResponseEntity<String> getEmail() {
+        return ResponseEntity.status(HttpStatus.OK).body(SecurityUtils.getCurrentUserEmail());
+    }
+
+    @GetMapping("/kakao")
+    public ResponseEntity<String> kakaoLogin(@RequestParam String code) {
+        return ResponseEntity.ok(kakaoService.kakaoLogin(code));
+    }
+}

--- a/src/main/java/efub/assignment/community/auth/dto/response/KakaoTokenResponseDto.java
+++ b/src/main/java/efub/assignment/community/auth/dto/response/KakaoTokenResponseDto.java
@@ -1,0 +1,27 @@
+package efub.assignment.community.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor //역직렬화를 위한 기본 생성자
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoTokenResponseDto {
+
+    @JsonProperty("token_type")
+    public String tokenType;
+    @JsonProperty("access_token")
+    public String accessToken;
+    @JsonProperty("id_token")
+    public String idToken;
+    @JsonProperty("expires_in")
+    public Integer expiresIn;
+    @JsonProperty("refresh_token")
+    public String refreshToken;
+    @JsonProperty("refresh_token_expires_in")
+    public Integer refreshTokenExpiresIn;
+    @JsonProperty("scope")
+    public String scope;
+}

--- a/src/main/java/efub/assignment/community/auth/dto/response/TokenResponseDto.java
+++ b/src/main/java/efub/assignment/community/auth/dto/response/TokenResponseDto.java
@@ -1,0 +1,18 @@
+package efub.assignment.community.auth.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TokenResponseDto {
+
+    private String accessToken;
+
+    @Builder
+    public TokenResponseDto(final String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/efub/assignment/community/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/efub/assignment/community/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package efub.assignment.community.auth.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final TokenProvider tokenProvider;
+
+    private static final String BEARER = "Bearer ";
+    private static final String HEADER = "Authorization";
+
+    /**
+     * JWT 인증 필터
+     *
+     * HTTP 요청을 가로채 JWT 토큰을 검사하고, 유효한 경우 인증 정보를 설정
+     */
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        // 요청 헤더의 Authorization 키 값 조회
+        String authorizationHeader = request.getHeader(HEADER);
+
+        // Bearer 접두사를 제거하여 토큰 추출
+        String token = getAccessToken(authorizationHeader);
+
+        // 토큰이 유효한 경우, 인증 정보를 설정(SecurityContext에 인증정보 저장하여) 해당 요청동안 인증된 사용자 정보 받아올 수 있게 함.
+        if(!ObjectUtils.isEmpty(token) && tokenProvider.isValidToken(token)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        // 다음 필터로 요청과 응답 전달
+        filterChain.doFilter(request, response);
+    }
+
+
+    /**
+     * Authorization 헤더에서 Bearer 접두사를 제거해 토큰 추출
+     */
+    private String getAccessToken(String authorizationHeader){
+        // Token이 null이 아니고 Bearer로 시작해야지 정상적인 Token
+        if(authorizationHeader != null && authorizationHeader.startsWith(BEARER)){
+            // 정상적인 토큰이라면 앞에 Bearer 제거 후 리턴
+            return authorizationHeader.substring(BEARER.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/efub/assignment/community/auth/jwt/TokenProvider.java
+++ b/src/main/java/efub/assignment/community/auth/jwt/TokenProvider.java
@@ -30,29 +30,14 @@ public class TokenProvider {
     private static Long accessTokenExpiration = 1000*60*60L;    // 1시간
     private static Long refreshTokenExpiration = 1000*60*60*25*14L; // 2주
 
+    // 토큰 redis 저장 prefix
+    private static final String REFRESH_TOKEN_KEY_PREFIX = "refresh_token:";
+
     // 토큰에 포함할 기본 정보와 클레임 키값 설정
     private static final String AUTH_CLAIM = "auth";
 
     private final MemberRepository memberRepository;
     private final RedisTemplate<String, String> redisTemplate;
-
-    /**
-     * AccessToken 생성 메소드
-     * 사용자 이메일 정보를 포함해 AccessToken 생성
-     */
-
-
-    /**
-     * RefreshToken 생성 메소드
-     */
-
-
-    /**
-     * Redis에 리프레시 토큰을 저장하는 메소드
-     * key: 사용자 ID, alue: 리프레시 토큰
-     * 리프레시토큰 만료 시간(refreshTokenExpiration)을 만료시간으로 정해 자동으로 삭제되도록 설정
-     */
-
 
     /**
      * AccessToken에서 email 추출
@@ -149,6 +134,6 @@ public class TokenProvider {
     }
 
     public void saveRefreshToken(Long accountId, String refreshToken) {
-        redisTemplate.opsForValue().set(accountId.toString(), refreshToken, Duration.ofMillis(refreshTokenExpiration));
+        redisTemplate.opsForValue().set(REFRESH_TOKEN_KEY_PREFIX + accountId.toString(), refreshToken, Duration.ofMillis(refreshTokenExpiration));
     }
 }

--- a/src/main/java/efub/assignment/community/auth/jwt/TokenProvider.java
+++ b/src/main/java/efub/assignment/community/auth/jwt/TokenProvider.java
@@ -1,0 +1,154 @@
+package efub.assignment.community.auth.jwt;
+
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.repository.MemberRepository;
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenProvider {
+
+    // application.yml에 저장한 jwt값 가져오기
+    @Value("${jwt.secret.Key}")
+    private String secretKey;
+
+    // 토큰 만료시간 설정
+    private static Long accessTokenExpiration = 1000*60*60L;    // 1시간
+    private static Long refreshTokenExpiration = 1000*60*60*25*14L; // 2주
+
+    // 토큰에 포함할 기본 정보와 클레임 키값 설정
+    private static final String AUTH_CLAIM = "auth";
+
+    private final MemberRepository memberRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * AccessToken 생성 메소드
+     * 사용자 이메일 정보를 포함해 AccessToken 생성
+     */
+
+
+    /**
+     * RefreshToken 생성 메소드
+     */
+
+
+    /**
+     * Redis에 리프레시 토큰을 저장하는 메소드
+     * key: 사용자 ID, alue: 리프레시 토큰
+     * 리프레시토큰 만료 시간(refreshTokenExpiration)을 만료시간으로 정해 자동으로 삭제되도록 설정
+     */
+
+
+    /**
+     * AccessToken에서 email 추출
+     * 토큰이 유효한지 확인 후 이메일 클레임 값을 추출
+     */
+    public String extractEmail(String accessToken){
+        if(isValidToken(accessToken)){
+            return getClaims(accessToken).getSubject();
+        }
+        return null;
+    }
+
+    /**
+     * 유효한 토큰인지 검증
+     */
+    public boolean isValidToken(String token){
+        try{
+            // secretKey를 사용해 토큰 복호화
+            Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            log.info("Validate token success");
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty", e);
+        }
+        return false;
+    }
+
+    /**
+     * 토큰에서 사용자 인증 정보를 꺼내 반환
+     * JWT 토큰의 클레임에서 사용자 이메일과 권한 정보를 추출하여 Authentication 객체를 생성
+     */
+    public Authentication getAuthentication(String token){
+        // 토큰 복호화
+        Claims claims = getClaims(token);
+
+        // 토큰에서 정보를 꺼냄
+        Set<SimpleGrantedAuthority> authorities = Collections
+                .singleton(new SimpleGrantedAuthority("ROLE_USER"));
+
+        return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails
+                .User(claims.getSubject(), "", authorities), token, authorities);
+    }
+
+    /**
+     * 토큰을 복호화한 후 페이로드 반환
+     */
+    private Claims getClaims(String token){
+        return Jwts.parser()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getPayload();
+    }
+
+    public String createAccessToken(Member member) {
+        Date now = new Date();
+        return Jwts.builder()
+                // 헤더 - 토큰타입: jwt
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                // 내용 - 토큰이 발급된 시간: 현재 시간
+                .setIssuedAt(now)
+                // 내용 - 토큰 만료 시간: expiredMs 변수값
+                .setExpiration(new Date(now.getTime() + accessTokenExpiration))
+                // 내용 - 토큰 제목 : 사용자 이메일
+                .setSubject(member.getEmail())
+                // 서명 - 시크릿키와 함께 해시값을 HS256 방식으로 암호화
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public String createRefreshToken(Member member) {
+        Date now = new Date();
+        return Jwts.builder()
+                // 헤더 - 토큰타입: jwt
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                // 내용 - 토큰이 발급된 시간: 현재 시간
+                .setIssuedAt(now)
+                // 내용 - 토큰 만료 시간: expiredMs 변수값
+                .setExpiration(new Date(now.getTime() + refreshTokenExpiration))
+                // 내용 - 토큰 제목 : 사용자 이메일
+                .setSubject(member.getEmail())
+                // 서명 - 시크릿키와 함께 해시값을 HS256 방식으로 암호화
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public void saveRefreshToken(Long accountId, String refreshToken) {
+        redisTemplate.opsForValue().set(accountId.toString(), refreshToken, Duration.ofMillis(refreshTokenExpiration));
+    }
+}

--- a/src/main/java/efub/assignment/community/auth/service/AuthService.java
+++ b/src/main/java/efub/assignment/community/auth/service/AuthService.java
@@ -1,0 +1,55 @@
+package efub.assignment.community.auth.service;
+
+import efub.assignment.community.auth.dto.response.TokenResponseDto;
+import efub.assignment.community.auth.jwt.TokenProvider;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * AccessToken 재발급
+     *
+     * 클라이언트가 전달한 리프레시 토큰을 검증해 유효한 경우 새로운 액세스토큰을 발급한다.
+     */
+    public TokenResponseDto reissueAccessToken(String refreshToken){
+        // 전달받은 리프레시 토큰에서 이메일을 추출하여 사용자 정보 가져오기
+        String email = tokenProvider.extractEmail(refreshToken);
+        Member member = getUserByEmail(email);
+
+        // Redis에서 해당 사용자 Id를 키로 하는 리프래시 토큰 가져오기
+        String storedRefreshToken = redisTemplate.opsForValue().get(member.getMemberId().toString());
+
+        // 전달받은 리프레시 토큰과 Redis에 저장된 리프레시 토큰이 일치하는지 확인
+        if(storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)){
+            throw new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다.");
+        }
+
+        // 일치한다면 새로운 AccessToken 생성
+        String accessToken = tokenProvider.createAccessToken(member);
+
+        return TokenResponseDto.builder()
+                .accessToken(accessToken)
+                .build();
+
+    }
+
+    /**
+     * Email로 사용자 객체 가져오기
+     */
+    @Transactional(readOnly = true)
+    public Member getUserByEmail(String email){
+        return memberRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("해당 이메일로 사용자를 찾을 수 없습니다."));
+    }
+
+}

--- a/src/main/java/efub/assignment/community/auth/service/AuthService.java
+++ b/src/main/java/efub/assignment/community/auth/service/AuthService.java
@@ -17,11 +17,6 @@ public class AuthService {
     private final TokenProvider tokenProvider;
     private final RedisTemplate<String, String> redisTemplate;
 
-    /**
-     * AccessToken 재발급
-     *
-     * 클라이언트가 전달한 리프레시 토큰을 검증해 유효한 경우 새로운 액세스토큰을 발급한다.
-     */
     public TokenResponseDto reissueAccessToken(String refreshToken){
         // 전달받은 리프레시 토큰에서 이메일을 추출하여 사용자 정보 가져오기
         String email = tokenProvider.extractEmail(refreshToken);
@@ -44,9 +39,6 @@ public class AuthService {
 
     }
 
-    /**
-     * Email로 사용자 객체 가져오기
-     */
     @Transactional(readOnly = true)
     public Member getUserByEmail(String email){
         return memberRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("해당 이메일로 사용자를 찾을 수 없습니다."));

--- a/src/main/java/efub/assignment/community/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/efub/assignment/community/auth/service/CustomOAuth2UserService.java
@@ -21,7 +21,7 @@ import java.util.Map;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class GoogleOAuth2UserService implements OAuth2UserService {
+public class CustomOAuth2UserService implements OAuth2UserService {
 
     private final MemberRepository memberRepository;
 
@@ -50,12 +50,6 @@ public class GoogleOAuth2UserService implements OAuth2UserService {
         );
     }
 
-    /**
-     * 사용자 생성 메서드
-     * - 처음으로 소셜 로그인을 시도하는 사용자를 우리 데이터베이스에 자동으로 등록해주는 메서드 생성
-     *
-     * OAuth2로그인은 비밀번호가 필요하지 않으므로 ""
-     */
     private Member createAccount(OAuth2UserInfo oAuth2UserInfo){
         Member member = Member.builder()
                 .email(oAuth2UserInfo.getEmail())

--- a/src/main/java/efub/assignment/community/auth/service/GoogleOAuth2UserService.java
+++ b/src/main/java/efub/assignment/community/auth/service/GoogleOAuth2UserService.java
@@ -1,0 +1,68 @@
+package efub.assignment.community.auth.service;
+
+import efub.assignment.community.auth.utils.OAuth2UserInfo;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GoogleOAuth2UserService implements OAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // Oauth2 사용자 정보 로드
+        OAuth2User oAuth2User = new DefaultOAuth2UserService().loadUser(userRequest);
+
+        // 구글 OAuth2UserInfo 객체 생성
+        OAuth2UserInfo oAuth2UserInfo = new OAuth2UserInfo(oAuth2User.getAttributes());
+
+        // DB에서 해당 사용자 조회 -> 없으면 새로 생성
+        Member member = memberRepository.findByEmail(oAuth2UserInfo.getEmail())
+                .orElseGet(() -> createAccount(oAuth2UserInfo));
+
+        // 사용자 속성 생성
+        Map<String, Object> attributes = new HashMap<>(oAuth2User.getAttributes());
+        attributes.put("id", member.getMemberId());
+        attributes.put("email", member.getEmail());
+
+        //DefaultOAuth2User 객체 생성하여 반환
+        return new DefaultOAuth2User(
+                Collections.singleton(new OAuth2UserAuthority(attributes)),
+                attributes,
+                "email"
+        );
+    }
+
+    /**
+     * 사용자 생성 메서드
+     * - 처음으로 소셜 로그인을 시도하는 사용자를 우리 데이터베이스에 자동으로 등록해주는 메서드 생성
+     *
+     * OAuth2로그인은 비밀번호가 필요하지 않으므로 ""
+     */
+    private Member createAccount(OAuth2UserInfo oAuth2UserInfo){
+        Member member = Member.builder()
+                .email(oAuth2UserInfo.getEmail())
+                .password("")
+                .nickname(oAuth2UserInfo.getNickname())
+                .build();
+        return memberRepository.save(member);
+    }
+
+}

--- a/src/main/java/efub/assignment/community/auth/service/KakaoService.java
+++ b/src/main/java/efub/assignment/community/auth/service/KakaoService.java
@@ -1,6 +1,7 @@
 package efub.assignment.community.auth.service;
 
 import efub.assignment.community.auth.dto.response.KakaoTokenResponseDto;
+import efub.assignment.community.auth.dto.response.TokenResponseDto;
 import efub.assignment.community.auth.jwt.TokenProvider;
 import efub.assignment.community.auth.utils.KakaoUtils;
 import efub.assignment.community.member.domain.Member;
@@ -26,20 +27,19 @@ public class KakaoService {
     private final TokenProvider tokenProvider;
     private final MemberRepository memberRepository;
 
-    public String kakaoLogin(String code){
+    public TokenResponseDto kakaoLogin(String code){
         // 1. 인가 코드로 AccessToken 받기
         String kakaoAccessToken = getAccessTokenFromKakao(code);
 
         // 2. 카카오 사용자 정보 요청
         Map<String, Object> kakaoUserInfo = getUserInfo(kakaoAccessToken);
-        String email = (String) kakaoUserInfo.get("email");
         String nickname = (String) kakaoUserInfo.get("nickname");
 
         // 3. DB에 사용자 존재 여부 확인
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByNickname(nickname)
                 .orElseGet(() -> memberRepository.save(
                         Member.builder()
-                                .email(email)
+                                .email("")
                                 .nickname(nickname)
                                 .password("")
                                 .studentId("")
@@ -47,13 +47,13 @@ public class KakaoService {
                                 .build()
                 ));
 
-        // 4. JWT 발급
+        // 4. JWT 발급 및 redis에 저장
         String accessToken = tokenProvider.createAccessToken(member);
         String refreshToken = tokenProvider.createRefreshToken(member);
         tokenProvider.saveRefreshToken(member.getMemberId(), refreshToken);
 
         // 5. 응답 반환
-        return String.format("{\"accessToken\": \"%s\", \"refreshToken\": \"%s\"}", accessToken, refreshToken);
+        return TokenResponseDto.builder().accessToken(accessToken).build();
     }
 
     public String getAccessTokenFromKakao(String code) {

--- a/src/main/java/efub/assignment/community/auth/service/KakaoService.java
+++ b/src/main/java/efub/assignment/community/auth/service/KakaoService.java
@@ -1,0 +1,102 @@
+package efub.assignment.community.auth.service;
+
+import efub.assignment.community.auth.dto.response.KakaoTokenResponseDto;
+import efub.assignment.community.auth.jwt.TokenProvider;
+import efub.assignment.community.auth.utils.KakaoUtils;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.repository.MemberRepository;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class KakaoService {
+
+    private final KakaoUtils kakaoUtils;
+    private final TokenProvider tokenProvider;
+    private final MemberRepository memberRepository;
+
+    public String kakaoLogin(String code){
+        // 1. 인가 코드로 AccessToken 받기
+        String kakaoAccessToken = getAccessTokenFromKakao(code);
+
+        // 2. 카카오 사용자 정보 요청
+        Map<String, Object> kakaoUserInfo = getUserInfo(kakaoAccessToken);
+        String email = (String) kakaoUserInfo.get("email");
+        String nickname = (String) kakaoUserInfo.get("nickname");
+
+        // 3. DB에 사용자 존재 여부 확인
+        Member member = memberRepository.findByEmail(email)
+                .orElseGet(() -> memberRepository.save(
+                        Member.builder()
+                                .email(email)
+                                .nickname(nickname)
+                                .password("")
+                                .studentId("")
+                                .university("ewha")
+                                .build()
+                ));
+
+        // 4. JWT 발급
+        String accessToken = tokenProvider.createAccessToken(member);
+        String refreshToken = tokenProvider.createRefreshToken(member);
+        tokenProvider.saveRefreshToken(member.getMemberId(), refreshToken);
+
+        // 5. 응답 반환
+        return String.format("{\"accessToken\": \"%s\", \"refreshToken\": \"%s\"}", accessToken, refreshToken);
+    }
+
+    public String getAccessTokenFromKakao(String code) {
+
+        KakaoTokenResponseDto kakaoTokenResponseDto = WebClient.create(kakaoUtils.getTokenUrl()).post()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .queryParam("grant_type", "authorization_code")
+                        .queryParam("client_id", kakaoUtils.getClientId())
+                        .queryParam("code", code)
+                        .build(true))
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                //TODO : Custom Exception
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Invalid Parameter")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("Internal Server Error")))
+                .bodyToMono(KakaoTokenResponseDto.class)
+                .block();
+
+
+        log.info(" [Kakao Service] Access Token ------> {}", kakaoTokenResponseDto.getAccessToken());
+        log.info(" [Kakao Service] Refresh Token ------> {}", kakaoTokenResponseDto.getRefreshToken());
+        //제공 조건: OpenID Connect가 활성화 된 앱의 토큰 발급 요청인 경우 또는 scope에 openid를 포함한 추가 항목 동의 받기 요청을 거친 토큰 발급 요청인 경우
+        log.info(" [Kakao Service] Id Token ------> {}", kakaoTokenResponseDto.getIdToken());
+        log.info(" [Kakao Service] Scope ------> {}", kakaoTokenResponseDto.getScope());
+
+        return kakaoTokenResponseDto.getAccessToken();
+    }
+
+    public Map<String, Object> getUserInfo(String accessToken) {
+        Map<String, Object> userInfo = WebClient.create(kakaoUtils.getUserInfoUrl()).get()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+
+        // 필요한 정보 추출 (email, nickname 등)
+        Map<String, Object> kakaoAccount = (Map<String, Object>) userInfo.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("email", kakaoAccount.get("email"));
+        result.put("nickname", profile.get("nickname"));
+        return result;
+    }
+}

--- a/src/main/java/efub/assignment/community/auth/utils/KakaoUtils.java
+++ b/src/main/java/efub/assignment/community/auth/utils/KakaoUtils.java
@@ -1,0 +1,24 @@
+package efub.assignment.community.auth.utils;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class KakaoUtils {
+    private final String clientId;
+    private final String redirectUri;
+    private final String tokenUrl;
+    private final String userInfoUrl;
+
+    public KakaoUtils(@Value("${kakao.client-id}") String clientId,
+                      @Value("${kakao.redirect-uri}") String redirectUri,
+                      @Value("${kakao.provider.kakao.token-uri}") String tokenUrl,
+                      @Value("${kakao.provider.kakao.user-info-uri}") String userInfoUrl) {
+        this.clientId = clientId;
+        this.redirectUri = redirectUri;
+        this.tokenUrl = tokenUrl;
+        this.userInfoUrl = userInfoUrl;
+    }
+}

--- a/src/main/java/efub/assignment/community/auth/utils/OAuth2UserInfo.java
+++ b/src/main/java/efub/assignment/community/auth/utils/OAuth2UserInfo.java
@@ -1,0 +1,20 @@
+package efub.assignment.community.auth.utils;
+
+import java.util.Map;
+
+public class OAuth2UserInfo {
+    private Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public String getNickname(){
+        return (String) attributes.get("name");
+    }
+
+    public String getEmail() {
+        return(String) attributes.get("email");
+    }
+
+}

--- a/src/main/java/efub/assignment/community/global/config/QueryDslConfig.java
+++ b/src/main/java/efub/assignment/community/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package efub.assignment.community.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory () {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/efub/assignment/community/global/config/RedisConfig.java
+++ b/src/main/java/efub/assignment/community/global/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package efub.assignment.community.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching // 캐싱 기능 활성화
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+
+}

--- a/src/main/java/efub/assignment/community/global/config/SecurityConfig.java
+++ b/src/main/java/efub/assignment/community/global/config/SecurityConfig.java
@@ -2,7 +2,7 @@ package efub.assignment.community.global.config;
 
 import efub.assignment.community.auth.jwt.JwtAuthenticationFilter;
 import efub.assignment.community.auth.jwt.TokenProvider;
-import efub.assignment.community.auth.service.GoogleOAuth2UserService;
+import efub.assignment.community.auth.service.CustomOAuth2UserService;
 import efub.assignment.community.global.handler.OAuth2AuthenticationSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -21,13 +21,9 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final TokenProvider tokenProvider;
-    private final GoogleOAuth2UserService customOAuth2UserService;
+    private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
 
-    /**
-     * SecurityFilterChain 설정을 위한 Bean 등록
-     * HTTP 요청에 대한 보안 구성을 정의하고, JWT 인증 필터 추가
-     */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
@@ -57,8 +53,6 @@ public class SecurityConfig {
                 .build();
     }
 
-
-    // ============== [ CORS 설정 Bean 추가 ] ==============
     @Bean
     public CorsConfigurationSource corsConfigurationSource(){
         CorsConfiguration configuration = new CorsConfiguration();
@@ -81,5 +75,4 @@ public class SecurityConfig {
         source.registerCorsConfiguration("/**", configuration);
         return source;
     }
-    // ===============================================
 }

--- a/src/main/java/efub/assignment/community/global/config/SecurityConfig.java
+++ b/src/main/java/efub/assignment/community/global/config/SecurityConfig.java
@@ -1,0 +1,85 @@
+package efub.assignment.community.global.config;
+
+import efub.assignment.community.auth.jwt.JwtAuthenticationFilter;
+import efub.assignment.community.auth.jwt.TokenProvider;
+import efub.assignment.community.auth.service.GoogleOAuth2UserService;
+import efub.assignment.community.global.handler.OAuth2AuthenticationSuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final TokenProvider tokenProvider;
+    private final GoogleOAuth2UserService customOAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    /**
+     * SecurityFilterChain 설정을 위한 Bean 등록
+     * HTTP 요청에 대한 보안 구성을 정의하고, JWT 인증 필터 추가
+     */
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                // 기본 인증 방식 비활성화 (UI 대신 토큰을 통한 인증을 사용하기 때문)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                // CSRF 보호 비활성화 (토큰 기반 인증이므로 필요하지 않음)
+                .csrf(AbstractHttpConfigurer::disable)
+                //cors 설정 추가
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                // 요청에 따른 인증 인가 설정
+                .authorizeHttpRequests(requests -> {
+                    /* 액세스토큰 재발급, GET요청은 모두 허용 */
+                    requests.requestMatchers("auth/token").permitAll();
+                    requests.requestMatchers(HttpMethod.GET).permitAll();
+                    /* 다른 모든 요청은 인증을 요구 */
+                    requests.anyRequest().authenticated();
+                })
+                // JWT를 사용하므로 sateless
+                .sessionManagement(
+                        sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                // JWT 인증 필터를 UsernamePAsswordAuthenticationFilter 앞에 추가하여 JWT를 통한 인증 수행
+                .addFilterBefore(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+                // OAuth2 로그인 설정 - 인증된 사용자 정보(프로필)를 가져오는 방식 정의, 인증 성공시 동작을 정의하는 successHandler 설정
+                .oauth2Login(oauth2 -> oauth2.userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                        .successHandler(oAuth2AuthenticationSuccessHandler))
+                .build();
+    }
+
+
+    // ============== [ CORS 설정 Bean 추가 ] ==============
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource(){
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        // 1. 허용할 출처(프론트엔드)를 명시
+        configuration.addAllowedOrigin("http://localhost:3000");
+
+        // 2. 허용할 HTTP 메서드(GET, POST 등)를 명시
+        configuration.addAllowedOrigin("*");
+
+        // 3. 허용할 HTTP 헤더를 명시
+        configuration.addAllowedHeader("*");
+
+        // 4. 자격 증명(쿠키, 인증 헤더 등)을 허용할지 여부를 설정
+        // true로 설정해야 Authorization 헤더에 담긴 JWT 토큰을 주고받기 가능
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        // 모든 경로(/)에 대해 위에서 정의한 CORS 설정을 적용
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+    // ===============================================
+}

--- a/src/main/java/efub/assignment/community/global/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/efub/assignment/community/global/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,57 @@
+package efub.assignment.community.global.handler;
+
+import efub.assignment.community.auth.jwt.TokenProvider;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.repository.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final TokenProvider tokenProvider;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        // OAuth2 인증된 사용자 정보 가져오기
+        DefaultOAuth2User oAuth2User = (DefaultOAuth2User) authentication.getPrincipal();
+
+        // 사용자 속성에서 이메일 추출
+        String email = (String) oAuth2User.getAttributes().get("email");
+
+        // email을 통해 데이터베이스에서 User 엔티티 조회
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("해당 이메일을 가진 Account를 찾을 수 없습니다. email="+email));
+
+        // AccessToken, RefreshToken 발급
+        String accessToken = tokenProvider.createAccessToken(member);
+        String refreshToken = tokenProvider.createRefreshToken(member);
+
+        // 리스레시토큰 저장
+        tokenProvider.saveRefreshToken(member.getMemberId(), refreshToken);
+
+        // JSON형식 응답 설정
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        // AccessToken, RefreshToken 토큰 전달
+        String jsonResponse = String.format("{\"accessToken\":\"%s\", \"refreshToken\":\"%s\"}", accessToken, refreshToken);
+        response.getWriter().write(jsonResponse);
+        response.getWriter().flush();
+    }
+}

--- a/src/main/java/efub/assignment/community/global/utils/SecurityUtils.java
+++ b/src/main/java/efub/assignment/community/global/utils/SecurityUtils.java
@@ -1,0 +1,18 @@
+package efub.assignment.community.global.utils;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtils {
+
+    public static String getCurrentUserEmail() {
+        // SecurityContext에서 현재 인증 정보를 가져옴.
+        Authentication authenication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 인증정보가 없어가 사용자 이름(이메일)이 없는 경우, null 반환
+        if (authenication == null || authenication.getName() == null) {
+            return null;
+        }
+        return authenication.getName();
+    }
+}

--- a/src/main/java/efub/assignment/community/member/domain/Member.java
+++ b/src/main/java/efub/assignment/community/member/domain/Member.java
@@ -36,7 +36,7 @@ public class Member extends BaseEntity {
     private String nickname;
 
     // 이메일
-    @Column (nullable = false, length = 100, unique = true)
+    @Column (nullable = true, length = 100, unique = true)
     private String email;
 
     // 비밀번호

--- a/src/main/java/efub/assignment/community/member/repository/MemberRepository.java
+++ b/src/main/java/efub/assignment/community/member/repository/MemberRepository.java
@@ -14,4 +14,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByMemberId(Long memberId);
     // email로 조회
     Optional<Member> findByEmail(String email);
+    // 닉네임으로 조회
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/efub/assignment/community/member/repository/MemberRepository.java
+++ b/src/main/java/efub/assignment/community/member/repository/MemberRepository.java
@@ -12,4 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
     // 멤버 ID로 조회
     Optional<Member> findByMemberId(Long memberId);
+    // email로 조회
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/efub/assignment/community/post/controller/PostController.java
+++ b/src/main/java/efub/assignment/community/post/controller/PostController.java
@@ -1,7 +1,5 @@
 package efub.assignment.community.post.controller;
 
-import efub.assignment.community.comment.dto.response.PostCommentResponseDto;
-import efub.assignment.community.comment.service.CommentService;
 import efub.assignment.community.post.dto.request.PostCreateRequestDto;
 import efub.assignment.community.post.dto.request.PostLikeDto;
 import efub.assignment.community.post.dto.response.PostListResponseDto;
@@ -13,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -61,5 +61,15 @@ public class PostController {
     public ResponseEntity<Boolean> toggleHeart(@Valid @RequestBody PostLikeDto request) {
         boolean liked = postService.toggleHeart(request);
         return ResponseEntity.ok(liked);
+    }
+
+    // 게시글 검색
+    @GetMapping("/search")
+    public ResponseEntity<List<PostResponseDto>> searchPost(
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "author", required = false) String authorName,
+            @RequestParam(value = "board", required = false) String boardName
+    ) {
+        return ResponseEntity.ok(postService.searchPost(keyword, authorName, boardName));
     }
 }

--- a/src/main/java/efub/assignment/community/post/repository/CustomPostRepository.java
+++ b/src/main/java/efub/assignment/community/post/repository/CustomPostRepository.java
@@ -1,0 +1,9 @@
+package efub.assignment.community.post.repository;
+
+import efub.assignment.community.post.domain.Post;
+
+import java.util.List;
+
+public interface CustomPostRepository {
+    List<Post> search(String keyword, String author, String boardName);
+}

--- a/src/main/java/efub/assignment/community/post/repository/CustomPostRepositoryImpl.java
+++ b/src/main/java/efub/assignment/community/post/repository/CustomPostRepositoryImpl.java
@@ -1,0 +1,48 @@
+package efub.assignment.community.post.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import efub.assignment.community.board.domain.QBoard;
+import efub.assignment.community.member.domain.QMember;
+import efub.assignment.community.post.domain.Post;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import efub.assignment.community.post.domain.QPost;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomPostRepositoryImpl implements  CustomPostRepository{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Post> search(String keyword, String authorName, String boardName) {
+        QPost post = QPost.post;
+        QMember member = QMember.member;
+        QBoard board = QBoard.board;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if(authorName != null && !authorName.isBlank()){
+            builder.and(post.author.nickname.eq(authorName));
+        }
+
+        if(keyword != null && !keyword.isBlank()){
+            builder.and(post.content.containsIgnoreCase(keyword));
+        }
+
+        if(boardName != null && !boardName.isBlank()){
+            builder.and(post.board.name.eq(boardName));
+        }
+
+        return queryFactory.selectFrom(post)
+                .join(post.author, member).fetchJoin()
+                .join(post.board, board).fetchJoin()
+                .where(builder)
+                .orderBy(post.createdAt.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/efub/assignment/community/post/repository/PostRepository.java
+++ b/src/main/java/efub/assignment/community/post/repository/PostRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, CustomPostRepository {
     Optional<Post> findByPostId(Long postId);
 
     void deleteByPostId(Long postId);

--- a/src/main/java/efub/assignment/community/post/service/PostService.java
+++ b/src/main/java/efub/assignment/community/post/service/PostService.java
@@ -101,4 +101,11 @@ public class PostService {
                 .orElseThrow(() -> new IllegalArgumentException("Post Not Found"));
         return postHeartRepository.countByPost(post);
     }
+
+    @Transactional(readOnly = true)
+    public List<PostResponseDto> searchPost(String keyword, String authorName, String boardName) {
+        return postRepository.search(keyword, authorName, boardName).stream()
+                .map(PostResponseDto::from)
+                .toList();
+    }
 }

--- a/src/test/java/efub/assignment/community/member/controller/MemberControllerIntegrationTest.java
+++ b/src/test/java/efub/assignment/community/member/controller/MemberControllerIntegrationTest.java
@@ -18,8 +18,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 class MemberControllerIntegrationTest {

--- a/src/test/java/efub/assignment/community/post/controller/PostControllerIntegrationTest.java
+++ b/src/test/java/efub/assignment/community/post/controller/PostControllerIntegrationTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -23,8 +25,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 class PostControllerIntegrationTest {


### PR DESCRIPTION
## 📌 구현 기능  
- [x] QueryDsl 사용한 게시물 조회

## 🗂️ 과제 정리  
**keyword**로 게시물 조회
<img width="680" height="405" alt="image" src="https://github.com/user-attachments/assets/35af7ff4-dd25-4e47-b38d-e4e4560cce6c" />

**게시판 이름 + keyword**로 게시물 조회
<img width="683" height="406" alt="image" src="https://github.com/user-attachments/assets/9dfe60f6-a60e-467a-9dda-14f82e0a3d34" />

**게시판 이름 + keyword + 작성자명**으로 게시물 조회
<img width="671" height="343" alt="image" src="https://github.com/user-attachments/assets/37835165-1bdc-4a6e-a64d-7453d2ad6e9a" />


## ⚠️ 어려웠던 점  
- QPost, QMember 이런 Q 클래스들이 build > generated > querydsl에는 정상적으로 있는데, import를 불러오지 못하는 문제가 있었는데..
generated/querydsl 디렉토리를 "Generated Sources Root" 로 등록하니까 작동함!!
